### PR TITLE
Overlaps

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -39,6 +39,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("apply_gate_safe", &QuantumComputer::apply_gate_safe)
         .def("apply_gate", &QuantumComputer::apply_gate)
         .def("measure_circuit", &QuantumComputer::measure_circuit)
+        .def("perfect_measure_circuit", &QuantumComputer::perfect_measure_circuit)
         .def("direct_op_exp_val", &QuantumComputer::direct_op_exp_val)
         .def("direct_circ_exp_val", &QuantumComputer::direct_circ_exp_val)
         .def("direct_gate_exp_val", &QuantumComputer::direct_gate_exp_val)

--- a/src/qforte/experiment/experiment.py
+++ b/src/qforte/experiment/experiment.py
@@ -51,7 +51,7 @@ class Experiment(object):
             qc = qforte.QuantumComputer(self.n_qubits_)
 
             #2 build/update generator with params
-            self.generator_.set_parameters(params)
+            # self.generator_.set_parameters(params)
 
             #3 apply generator (once if prepare_each_time = False, N_sample times if)
             qc.apply_circuit(self.generator_)
@@ -65,6 +65,37 @@ class Experiment(object):
                 term_sum += self.operator_.terms()[k][0] * sum(measured)
 
             term_sum /= self.N_samples_
+
+            return numpy.real(term_sum)
+
+        elif(self.prepare_each_time_==True):
+            raise Exception('No support yet for measurement with multiple state preparations')
+
+    def perfect_experimental_avg(self, params):
+
+        """
+        calculates the exact experimental result of the operator the Experiment object was initialized with
+
+        :param params: (list) the list of parameters for the state preparation ansatz.
+
+        """
+
+        if(self.prepare_each_time_==False):
+            #1 initialize a quantum computer
+            qc = qforte.QuantumComputer(self.n_qubits_)
+
+            #2 build/update generator with params
+            # self.generator_.set_parameters(params)
+
+            #3 apply generator (once if prepare_each_time = False, N_sample times if)
+            qc.apply_circuit(self.generator_)
+
+            #4 measure operator
+            n_terms = len(self.operator_.terms())
+            term_sum = 0.0
+
+            for k in range(n_terms):
+                term_sum += self.operator_.terms()[k][0] * qc.perfect_measure_circuit(self.operator_.terms()[k][1]);
 
             return numpy.real(term_sum)
 

--- a/src/qforte/helper/operator_helper.py
+++ b/src/qforte/helper/operator_helper.py
@@ -2,7 +2,7 @@ import qforte
 from openfermion.ops import QubitOperator
 import numpy as np
 
-def build_from_openfermion(OF_qubitops):
+def build_from_openfermion(OF_qubitops, time_evo_factor = 1.0):
 
     """
     builds a QuantumOperator instance in
@@ -29,6 +29,6 @@ def build_from_openfermion(OF_qubitops):
             circ_term.add_gate(gate_this)
 
         #Add this term to operator
-        qforte_ops.add_term(coeff, circ_term)
+        qforte_ops.add_term(coeff*time_evo_factor, circ_term)
 
     return qforte_ops

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -4,7 +4,7 @@
 
 #include "quantum_gate.h"
 
-QuantumGate make_gate(std::string type, size_t target, size_t control, double parameter) {
+QuantumGate make_gate(std::string type, size_t target, size_t control, std::complex<double> parameter) {
     using namespace std::complex_literals;
     if (target == control) {
         if (type == "X") {

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -116,6 +116,17 @@ QuantumGate make_gate(std::string type, size_t target, size_t control, double pa
         }
 
     } else {
+        if (type == "A") {
+            std::complex<double> c = std::cos(parameter);
+            std::complex<double> s = std::sin(parameter);
+            std::complex<double> gate[4][4]{
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, c  ,  s,  0.0},
+                {0.0, s  , -c,  1.0},
+                {0.0, 0.0, 1.0, 0.0},
+            };
+            return QuantumGate(type, target, control, gate);
+        }
         if ((type == "cX") or (type == "CNOT")) {
             std::complex<double> gate[4][4]{
                 {1.0, 0.0, 0.0, 0.0},
@@ -162,6 +173,19 @@ QuantumGate make_gate(std::string type, size_t target, size_t control, double pa
                 {0.0, 1.0, 0.0, 0.0},
                 {0.0, 0.0, +a, +b},
                 {0.0, 0.0, +b, +a},
+            };
+            return QuantumGate(type, target, control, gate);
+        }
+        if (type == "cRz") {
+            std::complex<double> tmp_a = -1.0i * 0.5 * parameter;
+            std::complex<double> a = std::exp(tmp_a);
+            std::complex<double> tmp_b = 1.0i * 0.5 * parameter;
+            std::complex<double> b = std::exp(tmp_b);
+            std::complex<double> gate[4][4]{
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 1.0, 0.0, 0.0},
+                {0.0, 0.0, a,   0.0},
+                {0.0, 0.0, 0.0, b},
             };
             return QuantumGate(type, target, control, gate);
         }

--- a/src/qforte/quantum_computer.cc
+++ b/src/qforte/quantum_computer.cc
@@ -140,10 +140,6 @@ double QuantumComputer::perfect_measure_circuit(const QuantumCircuit& qc) {
     // copy old coefficients
     std::vector<std::complex<double>> old_coeff = coeff_;
 
-    // TODO: make code more readable (Nick)
-    // TODO: add gate lable not via enum? (Nick)
-    // TODO: Acount for case where gate is only the identity
-
     for (const QuantumGate& gate : qc.gates()) {
         size_t target_qubit = gate.target();
         std::string gate_id = gate.gate_id();
@@ -163,29 +159,6 @@ double QuantumComputer::perfect_measure_circuit(const QuantumCircuit& qc) {
 
     // apply Basis_rotator circuit to 'trick' qcomputer into measureing in non Z basis
     apply_circuit(Basis_rotator);
-    // std::vector<double> probs(nbasis_);
-    // for (size_t k = 0; k < nbasis_; k++) {
-    //     probs[k] = std::real(std::conj(coeff_[k]) * coeff_[k]);
-    // }
-
-    // random number device
-    // std::random_device rd;
-    // std::mt19937 gen(rd());
-
-    // 'pick' an index from the discrete_distribution!
-    // std::discrete_distribution<> dd(std::begin(probs), std::end(probs));
-
-    // std::vector<double> results(n_measurements);
-
-    // for (size_t k = 0; k < n_measurements; k++) {
-    //     size_t measurement = dd(gen);
-    //     double value = 1.;
-    //     for (const QuantumGate& gate : qc.gates()) {
-    //         size_t target_qubit = gate.target();
-    //         value *= 1. - 2. * static_cast<double>(basis_[measurement].get_bit(target_qubit));
-    //     }
-    //     results[k] = value;
-    // }
 
     double sum = 0.0;
     for (size_t k = 0; k < nbasis_; k++){

--- a/src/qforte/quantum_computer.cc
+++ b/src/qforte/quantum_computer.cc
@@ -132,6 +132,75 @@ std::vector<double> QuantumComputer::measure_circuit(const QuantumCircuit& qc,
     return results;
 }
 
+double QuantumComputer::perfect_measure_circuit(const QuantumCircuit& qc) {
+    // initialize a "Basis_rotator" QC to represent the corresponding change
+    // of basis
+    QuantumCircuit Basis_rotator;
+
+    // copy old coefficients
+    std::vector<std::complex<double>> old_coeff = coeff_;
+
+    // TODO: make code more readable (Nick)
+    // TODO: add gate lable not via enum? (Nick)
+    // TODO: Acount for case where gate is only the identity
+
+    for (const QuantumGate& gate : qc.gates()) {
+        size_t target_qubit = gate.target();
+        std::string gate_id = gate.gate_id();
+        if (gate_id == "Z") {
+            QuantumGate temp = make_gate("I", target_qubit, target_qubit);
+            Basis_rotator.add_gate(temp);
+        } else if (gate_id == "X") {
+            QuantumGate temp = make_gate("H", target_qubit, target_qubit);
+            Basis_rotator.add_gate(temp);
+        } else if (gate_id == "Y") {
+            QuantumGate temp = make_gate("Rzy", target_qubit, target_qubit);
+            Basis_rotator.add_gate(temp);
+        } else if (gate_id != "I") {
+            // std::cout<<'unrecognized gate in operator!'<<std::endl;
+        }
+    }
+
+    // apply Basis_rotator circuit to 'trick' qcomputer into measureing in non Z basis
+    apply_circuit(Basis_rotator);
+    // std::vector<double> probs(nbasis_);
+    // for (size_t k = 0; k < nbasis_; k++) {
+    //     probs[k] = std::real(std::conj(coeff_[k]) * coeff_[k]);
+    // }
+
+    // random number device
+    // std::random_device rd;
+    // std::mt19937 gen(rd());
+
+    // 'pick' an index from the discrete_distribution!
+    // std::discrete_distribution<> dd(std::begin(probs), std::end(probs));
+
+    // std::vector<double> results(n_measurements);
+
+    // for (size_t k = 0; k < n_measurements; k++) {
+    //     size_t measurement = dd(gen);
+    //     double value = 1.;
+    //     for (const QuantumGate& gate : qc.gates()) {
+    //         size_t target_qubit = gate.target();
+    //         value *= 1. - 2. * static_cast<double>(basis_[measurement].get_bit(target_qubit));
+    //     }
+    //     results[k] = value;
+    // }
+
+    double sum = 0.0;
+    for (size_t k = 0; k < nbasis_; k++){
+        double value = 1.0;
+        for (const QuantumGate& gate : qc.gates()) {
+            size_t target_qubit = gate.target();
+            value *= 1. - 2. * static_cast<double>(basis_[k].get_bit(target_qubit));
+        }
+        sum += std::real(value * coeff(basis_[k]) * std::conj(coeff(basis_[k])));
+    }
+
+    coeff_ = old_coeff;
+    return sum;
+}
+
 #include <iostream>
 
 void QuantumComputer::apply_1qubit_gate_safe(const QuantumGate& qg) {

--- a/src/qforte/quantum_computer.h
+++ b/src/qforte/quantum_computer.h
@@ -37,6 +37,9 @@ class QuantumComputer {
     /// measure the state of the quanum computer with respect to qc
     std::vector<double> measure_circuit(const QuantumCircuit& qc, size_t n_measurements);
 
+    /// perfectly measure the state of the quanum computer in basis of circuit
+    double perfect_measure_circuit(const QuantumCircuit& qc);
+
     /// get the expectation value of the sum of many circuits directly
     /// (ie without simulated measurement)
     std::complex<double> direct_op_exp_val(const QuantumOperator& qo);

--- a/src/qforte/quantum_gate.h
+++ b/src/qforte/quantum_gate.h
@@ -76,7 +76,7 @@ class QuantumGate {
 /// Create a quantum gate
 // QuantumGate make_gate(std::string type, size_t target, size_t control,
 //                               double parameter = 0.0, bool mirror = false);
-QuantumGate make_gate(std::string type, size_t target, size_t control, double parameter = 0.0);
+QuantumGate make_gate(std::string type, size_t target, size_t control, std::complex<double> parameter = 0.0);
 
 QuantumGate make_control_gate(size_t control, QuantumGate& U);
 

--- a/src/qforte/utils/exponentiate.py
+++ b/src/qforte/utils/exponentiate.py
@@ -5,7 +5,7 @@ Functions for exponentiation of qubit operator terms (circuits)
 import qforte
 import numpy
 
-def exponentiate_single_term(factor, term):
+def exponentiate_single_term(factor, term, Use_cRz=False, ancilla_idx=None, Use_open_cRz=False):
     """
     returns the exponential of an string of Pauli operators multiplied by an imaginary factor
 
@@ -57,12 +57,24 @@ def exponentiate_single_term(factor, term):
         max_target = target
 
     #gate that actually contains the parameterization for the term
-    z_rot = qforte.make_gate('Rz', max_target, max_target, 2.0 * numpy.imag(factor))
+    # TODO(Nick): investigate real/imaginary usage of 'factor' in below expression
+
+    if(Use_cRz):
+        z_rot = qforte.make_gate('cRz', max_target, ancilla_idx, 2.0 * numpy.imag(factor))
+    else:
+        z_rot = qforte.make_gate('Rz', max_target, max_target, 2.0 * numpy.imag(factor))
 
     #assemble the actual exponential
     exponential.add_circuit(to_z)
     exponential.add_circuit(cX_circ)
+
+    if(Use_open_cRz):
+        exponential.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+
     exponential.add_gate(z_rot)
+
+    if(Use_open_cRz):
+        exponential.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
 
     adj_cX_circ = cX_circ.adjoint()
     exponential.add_circuit(adj_cX_circ)

--- a/src/qforte/utils/trotterization.py
+++ b/src/qforte/utils/trotterization.py
@@ -38,3 +38,51 @@ def trotterize(operator, trotter_number=1, trotter_order=1):
             total_phase *= phase
 
     return (troterized_operator, total_phase)
+
+def trotterize_w_cRz(operator, ancilla_qubit_idx, Use_open_cRz=False, trotter_number=1, trotter_order=1):
+
+    """
+    returns a circuit equivilant to an exponentiated QuantumOperator in which each term
+    in the trotterization exp(-i * theta_k ) only acts on the register if the ancilla
+    qubit is in the |1> state.
+
+    :param operator: (QuantumOperator) the operator or state preparation ansatz
+    (represented as a sum of pauli terms) to be exponentiated
+
+    :param ancilla_qubit_idx: (int) the index of the ancilla qubit
+
+    :param Use_open_cRz: (bool) uses an open controlled Rz gate in exponentiation
+    (see Fig. 11 on page 185 of Nielson and Chung's
+    "Quantum Computation and Quantum Informatoin 10th Aniversary Ed.")
+
+    :param trotter_number: (int) for an operator A with terms A_i, the trotter_number
+    is the exponent (N) for to product of single term
+    exponentals e^A ~ ( Product_i(e^(A_i/N)) )^N
+
+    :param trotter_order: (int) the order of the troterization approximation, can be 1 or 2
+    """
+
+    if(trotter_order > 1) or (trotter_order <= 0):
+        raise ValueError("trotterization currently only supports trotter order = 1")
+    if(trotter_number > 1) or (trotter_number <= 0):
+        raise ValueError("trotterization currently only supports trotter number = 1")
+
+    total_phase = 1.0
+    troterized_operator = qforte.QuantumCircuit()
+
+    if (trotter_order == 1) and (trotter_number == 1):
+        #loop over terms in operator
+        if(Use_open_cRz):
+            for term in operator.terms():
+                term_generator, phase = qforte.exponentiate_single_term(term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
+                for gate in term_generator.gates():
+                    troterized_operator.add_gate(gate)
+                total_phase *= phase
+        else:
+            for term in operator.terms():
+                term_generator, phase = qforte.exponentiate_single_term(term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
+                for gate in term_generator.gates():
+                    troterized_operator.add_gate(gate)
+                total_phase *= phase
+
+    return (troterized_operator, total_phase)

--- a/tests/experiment_test.py
+++ b/tests/experiment_test.py
@@ -59,7 +59,66 @@ class ExperimentTests(unittest.TestCase):
 
         experimental_error = abs(avg_energy - E_hf)
 
-        self.assertLess(experimental_error, 2.0e-4)
+        self.assertLess(experimental_error, 4.0e-4)
+
+    def test_H2_experiment_perfect(self):
+        print('\n')
+        #the RHF H2 energy at equilibrium bond length
+        E_hf = -1.1166843870661929
+
+        #the H2 qubit hamiltonian
+        circ_vec = [qforte.QuantumCircuit(),
+        qforte.build_circuit('Z_0'),
+        qforte.build_circuit('Z_1'),
+        qforte.build_circuit('Z_2'),
+        qforte.build_circuit('Z_3'),
+        qforte.build_circuit('Z_0 Z_1'),
+        qforte.build_circuit('Y_0 X_1 X_2 Y_3'),
+        qforte.build_circuit('Y_0 Y_1 X_2 X_3'),
+        qforte.build_circuit('X_0 X_1 Y_2 Y_3'),
+        qforte.build_circuit('X_0 Y_1 Y_2 X_3'),
+        qforte.build_circuit('Z_0 Z_2'),
+        qforte.build_circuit('Z_0 Z_3'),
+        qforte.build_circuit('Z_1 Z_2'),
+        qforte.build_circuit('Z_1 Z_3'),
+        qforte.build_circuit('Z_2 Z_3')]
+
+        coef_vec = [-0.098863969784274,
+        0.1711977489805748,
+        0.1711977489805748,
+        -0.222785930242875,
+        -0.222785930242875,
+        0.1686221915724993,
+        0.0453222020577776,
+        -0.045322202057777,
+        -0.045322202057777,
+        0.0453222020577776,
+        0.1205448220329002,
+        0.1658670240906778,
+        0.1658670240906778,
+        0.1205448220329002,
+        0.1743484418396386]
+
+        H2_qubit_hamiltonian = qforte.QuantumOperator()
+        for i in range(len(circ_vec)):
+            H2_qubit_hamiltonian.add_term(coef_vec[i], circ_vec[i])
+
+        # circuit for making HF state
+        circ = qforte.QuantumCircuit()
+        circ.add_gate(qforte.make_gate('X', 0, 0))
+        circ.add_gate(qforte.make_gate('X', 1, 1))
+
+        TestExperiment = qforte.Experiment(4, circ, H2_qubit_hamiltonian, 1000000)
+        params2 = []
+        avg_energy = TestExperiment.perfect_experimental_avg(params2)
+        print('Perfectly Measured H2 Experimental Avg. Energy')
+        print(avg_energy)
+        print('H2 RHF Energy')
+        print(E_hf)
+
+        experimental_error = abs(avg_energy - E_hf)
+
+        self.assertAlmostEqual(experimental_error, 0.0)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/trotter_test.py
+++ b/tests/trotter_test.py
@@ -31,5 +31,56 @@ class ExperimentTests(unittest.TestCase):
         self.assertAlmostEqual(coeffs[1],-0.5421829373 +0.0j)
         self.assertAlmostEqual(coeffs[2], 0.840260473 +0.0j)
 
+    def test_trotterization_with_controlled_U(self):
+
+        circ_vec = [qforte.build_circuit('Y_0 X_1'), qforte.build_circuit('X_0 Y_1')]
+        coef_vec = [-1.0719145972781818j, 1.0719145972781818j]
+
+        # the operator to be exponentiated
+        generator = qforte.QuantumOperator()
+        for i in range(len(circ_vec)):
+            generator.add_term(coef_vec[i], circ_vec[i])
+
+        ancilla_idx = 2
+
+        # exponentiate the operator
+        troterized_gen, phase = qforte.trotterization.trotterize_w_cRz(generator, ancilla_idx)
+
+        # Case 1: positive control
+
+        # initalize a quantum computer
+        qc = qforte.QuantumComputer(3)
+
+        # build HF state
+        qc.apply_gate(qforte.make_gate('X', 0, 0))
+        qc.apply_gate(qforte.make_gate('X', 2, 2))
+
+        # apply the troterized generator
+        qc.apply_circuit(troterized_gen)
+
+        qforte.smart_print(qc)
+
+        coeffs = qc.get_coeff_vec()
+
+        self.assertAlmostEqual(coeffs[5],-0.5421829373 +0.0j)
+        self.assertAlmostEqual(coeffs[6], 0.840260473 +0.0j)
+
+        # Case 2: negitive control
+
+        # initalize a quantum computer
+        qc = qforte.QuantumComputer(3)
+
+        # build HF state
+        qc.apply_gate(qforte.make_gate('X', 0, 0))
+
+        # apply the troterized generator
+        qc.apply_circuit(troterized_gen)
+
+        qforte.smart_print(qc)
+
+        coeffs = qc.get_coeff_vec()
+
+        self.assertAlmostEqual(coeffs[1], 1.0 +0.0j)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR addes features (including test cases) for functions necessary to compute overlaps of the form <Um Psi | Un Psi>. This includes a function which creates circuits for troterized operators as controlled unitaries. This PR also adds a function which measures operators with the experiment class without stochastic sampling.  