### PR TITLE
Add add a Molecule class, and MolAdapter class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,10 @@ script:
 - conda update -q conda
 - conda info -a
 - conda create -q -n qforte python=$PYTHON_VER numpy cmake
+- python -m conda install psi4
 - source activate qforte
 - python -m pip install --user openfermion
+- python -m pip install --user openfermionpsi4
 - python -V
 - cd ${TRAVIS_BUILD_DIR}
 - export CXX=${CXX_COMPILER}

--- a/src/qforte/__init__.py
+++ b/src/qforte/__init__.py
@@ -3,8 +3,9 @@ __author__ = 'Qforte Dev'
 #sys.path.insert(1, os.path.abspath('.'))
 
 from .qforte import *
+from qforte.adapters import *
 from qforte.helper import *
-from qforte.experiment import * 
+from qforte.experiment import *
+from qforte.system import *
 #from qforte.vqe import *
 from qforte.utils import *
-

--- a/src/qforte/adapters/__init__.py
+++ b/src/qforte/adapters/__init__.py
@@ -1,0 +1,1 @@
+from .molecule_adapters import *

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -1,0 +1,155 @@
+"""
+A class for the building molecular object adapters. Adapters for various approaches to build
+the molecular info and properties (hamiltonian, rdms, etc...).
+"""
+
+from abc import ABC, abstractmethod
+
+from qforte.helper.operator_helper import build_from_openfermion
+from qforte.system.molecular_info import Molecule
+
+from openfermion.ops import QubitOperator
+from openfermion.hamiltonians import MolecularData
+from openfermion.transforms import get_fermion_operator, jordan_wigner
+from openfermion.utils import hermitian_conjugated, normal_ordered
+
+from openfermionpsi4 import run_psi4
+
+class MolAdapter(ABC):
+    """Abstract class for the aquiring system information from external electronic
+    structure calculations. The run() method calculates the desired properties and
+    data for the molecular system. Infromation is then stored in the
+    self._qforte_mol attribuite.
+    """
+
+    @abstractmethod
+    def run(self, **kwargs):
+        pass
+
+    @abstractmethod
+    def get_molecule(self):
+        pass
+
+
+class OpenFermionMolAdapter(MolAdapter):
+    """Class which builds a Molecule object using openfermion as a backend.
+    By default, it runs a scf calcuation and stores the qubit hamiltonian
+    (hamiltonian in
+    poly word representation).
+
+    Atributes
+    ---------
+    _mol_geometry : list of tuples
+        Gives coordinates of each atom in Angstroms. Example format is
+        geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 1.50))]. It serves
+        as an argument for the MolecularData class in openfermion.
+
+    _basis : string
+        Gives the basis set to be used. Default is 'sto-3g'. It serves
+        as an argument for the MolecularData class in openfermion.
+
+    _multiplicity : int
+        Gives the targeted spin multiplicity of the molecular system. It serves
+        as an argument for the MolecularData class in openfermion.
+
+    _charge : int
+        Gives the targeted net charge of the molecular system (controls number of
+        electrons to be considered). It serves as an argument for the
+        MolecularData class in openfermion.
+
+    _description : optional, string
+        Recomeded to use to distingush various runs
+        (for example with differnet bond lengths or geometric configurations).
+
+    _filename : optional, string
+        Specifies the name of the .hdf5 file molecular data from psi4/pyscf
+        calculation will be stored in.
+
+    _hdf5_dir : optional, string
+        Specifies the directory in which to store the .hdf5 file molecular
+        data from psi4/pyscf calculation will be stored in.
+        Default is "<openfermion_src_dir>/data".
+
+
+    _qforte_mol : Molecule
+        The qforte Molecule object which holds the molecular information.
+
+    """
+
+    def __init__(self, **kwargs):
+        self._mol_geometry = kwargs['mol_geometry']
+        self._basis = kwargs['basis']
+        self._multiplicity = kwargs['multiplicity']
+        self._charge = kwargs['charge']
+        self._description = kwargs['description']
+        self._filename = kwargs['filename']
+        self._hdf5_dir = kwargs['hdf5_dir']
+
+        self._qforte_mol = Molecule(mol_geometry = kwargs['mol_geometry'],
+                                   basis = kwargs['basis'],
+                                   multiplicity = kwargs['multiplicity'],
+                                   charge = kwargs['charge'],
+                                   description = kwargs['description'],
+                                   filename = kwargs['filename'],
+                                   hdf5_dir = kwargs['hdf5_dir'])
+
+    def run(self, **kwargs):
+
+        kwargs.setdefault('run_scf', 1)
+        kwargs.setdefault('run_mp2', 0)
+        kwargs.setdefault('run_ccsd', 0)
+        kwargs.setdefault('run_cisd', 0)
+        kwargs.setdefault('run_cisd', 0)
+        kwargs.setdefault('run_fci', 0)
+        kwargs.setdefault('store_uccsd_amps', False)
+        kwargs.setdefault('buld_uccsd_circ_from_ccsd', False)
+
+        skeleton_mol = MolecularData(geometry = self._mol_geometry,
+                                     basis = self._basis,
+                                     multiplicity = self._multiplicity,
+                                     charge = self._charge,
+                                     description = self._description,
+                                     filename = self._filename,
+                                     data_directory = self._hdf5_dir)
+
+        openfermion_mol = run_psi4(skeleton_mol, run_scf=kwargs['run_scf'],
+                                                 run_mp2=kwargs['run_mp2'],
+                                                 run_ccsd=kwargs['run_ccsd'],
+                                                 run_cisd=kwargs['run_cisd'],
+                                                 run_fci=kwargs['run_fci'])
+
+        openfermion_mol.load()
+
+        # Set qforte hamiltonian from openfermion
+        molecular_hamiltonian = openfermion_mol.get_molecular_hamiltonian()
+        fermion_hamiltonian = normal_ordered(get_fermion_operator(molecular_hamiltonian))
+        qubit_hamiltonian= jordan_wigner(fermion_hamiltonian)
+
+        qforte_hamiltionan = build_from_openfermion(qubit_hamiltonian)
+        self._qforte_mol.set_hamiltonian(qforte_hamiltionan)
+
+        # Set qforte energies from openfermion
+        if(kwargs['run_scf']==1):
+            self._qforte_mol.set_hf_energy(openfermion_mol.hf_energy)
+
+        if(kwargs['run_mp2']==1):
+            self._qforte_mol.set_mp2_energy(openfermion_mol.mp2_energy)
+
+        if(kwargs['run_cisd']==1):
+            self._qforte_mol.set_cisd_energy(openfermion_mol.cisd_energy)
+
+        if(kwargs['run_ccsd']==1):
+            self._qforte_mol.set_ccsd_energy(openfermion_mol.ccsd_energy)
+
+            # Store uccsd circuit with initial guess from ccsd amplitudes
+            if(kwargs['store_uccsd_amps']==True):
+                self._qforte_mol.set_ccsd_amps(openfermion_mol.ccsd_single_amps,
+                              openfermion_mol.ccsd_double_amps)
+
+        if(kwargs['run_fci']==1):
+            self._qforte_mol.set_fci_energy(openfermion_mol.fci_energy)
+
+
+
+    def get_molecule(self):
+        return self._qforte_mol

--- a/src/qforte/qforte.py
+++ b/src/qforte/qforte.py
@@ -4,7 +4,6 @@ qforte.py
 The core module of my example project
 """
 
-import experiment
 
 def about_me(your_name):
     """

--- a/src/qforte/system/__init__.py
+++ b/src/qforte/system/__init__.py
@@ -1,0 +1,2 @@
+from .molecular_info import *
+from .system_factory import *

--- a/src/qforte/system/molecular_info.py
+++ b/src/qforte/system/molecular_info.py
@@ -1,0 +1,129 @@
+"""
+A class for the system information, either a molecule or a lattice system such as
+Hubbard model.
+"""
+
+class Molecule(object):
+    """Class for storing moleucular information. Should be instatiated using using
+    a MolAdapter and populated by calling MolAdapter.run(**kwargs).
+
+
+    Atributes
+    ---------
+    _mol_geometry : list of tuples
+        Gives coordinates of each atom in Angstroms. Example format is
+        geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 1.50))].
+
+    _basis : string
+        Gives the basis set to be used. Default is 'sto-3g'.
+
+    _multiplicity : int
+        Gives the targeted spin multiplicity of the molecular system.
+
+    _charge : int
+        Gives the targeted net charge of the molecular system (controls number of
+        electrons to be considered).
+
+    _description : optional, string
+        Recomeded to use to distingush various runs
+        (for example with differnet bond lengths or geometric configurations),
+        if populated using a OpenFermionMolAdapter.
+
+
+    _filename : optional, string
+        Specifies the name of the .hdf5 file molecular data from psi4/pyscf
+        calculation will be stored in, if populated using a
+        OpenFermionMolAdapter.
+
+    _hdf5_dir : optional, string
+        Specifies the directory in which to store the .hdf5 file molecular
+        data from psi4/pyscf calculation will be stored in.
+        Default is "<openfermion_src_dir>/data", if populated using a
+        OpenFermionMolAdapter.
+
+    """
+
+    def __init__(self, mol_geometry=None, basis='sto-3g', multiplicity=1, charge=0,
+                 description="", filename="", hdf5_dir=None   ):
+        """Initialize a qforte molecule object.
+
+        Arguments
+        ---------
+        mol_geometry : tuple of tuples
+            Gives the coordinates of each atom in the moleucle.
+            An example is [('H', (0, 0, 0)), ('H', (0, 0, 0.7414))].
+            Distances in angstrom.
+
+        basis : string
+            Gives the basis set. Default is 'sto-3g'.
+
+        charge : int
+            Gives the total molecular charge. Defaults to 0.
+
+        multiplicity : int
+            Gives the spin multiplicity.
+
+        description : optional, string
+            Gives a description of the molecule.
+
+        filename : optional, string
+            Gives name of file to use if generating with OpenFermion-Psi4
+            or OpenFermion-pyscf.
+
+        hdf5_dir : optional, string
+            Optional data directory to change from default
+            data directory specified in config file if generating with
+            OpenFermion-Psi4 or OpenFermion-pyscf.
+        """
+
+        self.geometry = mol_geometry
+        self.basis = basis
+        self.multiplicity = multiplicity
+        self.charge = charge
+        self.description = description
+        self.filename = filename
+        self.hdf5_dir = hdf5_dir
+
+    def set_hamiltonian(self, hamiltonain_operator):
+        self._hamiltonian = hamiltonain_operator
+
+    def set_ccsd_amps(self, ccsd_singles, ccsd_doubles):
+        self._ccsd_singles = ccsd_singles
+        self._ccsd_doubles = ccsd_doubles
+
+    def set_hf_energy(self, hf_energy):
+        self._hf_energy = hf_energy
+
+    def set_mp2_energy(self, mp2_energy):
+        self._mp2_energy = mp2_energy
+
+    def set_cisd_energy(self, cisd_energy):
+        self._cisd_energy = cisd_energy
+
+    def set_ccsd_energy(self, ccsd_energy):
+        self._ccsd_energy = ccsd_energy
+
+    def set_fci_energy(self, fci_energy):
+        self._fci_energy = fci_energy
+
+
+    def get_ccsd_amps(self):
+        return self._ccsd_singles, self._ccsd_doubles
+
+    def get_hamiltonian(self):
+        return self._hamiltonian
+
+    def get_hf_energy(self):
+        return self._hf_energy
+
+    def get_mp2_energy(self):
+        return self._mp2_energy
+
+    def get_cisd_energy(self):
+        return self._cisd_energy
+
+    def get_ccsd_energy(self):
+        return self._ccsd_energy
+
+    def get_fci_energy(self):
+        return self._fci_energy

--- a/src/qforte/system/system_factory.py
+++ b/src/qforte/system/system_factory.py
@@ -1,0 +1,49 @@
+from qforte.adapters import molecule_adapters as MA
+
+def system_factory(stytem_type = 'molecule', build_type = 'openfermion', **kwargs):
+
+    """Builds an empty system object of type ('molecule', 'hubbard', 'jellium', etc...) using
+       adapters specified by build_type.
+
+        Arguments
+        ---------
+        system_type : string
+            Gives the type of system object to return.
+
+        build_type : string
+            Gives the method used to construct the system object. For example,
+            one could use OpenFermion, or one could just port directly from
+            Psi4 or pyscf.
+
+        Retruns
+        -------
+        my_sys_skeleton : MolAdapter
+            A molecular/hubbard/jellium... adapter object which can be used to
+            populate the system info.
+
+    """
+
+    kwargs.setdefault('basis', 'sto-3g')
+    kwargs.setdefault('multiplicity', 1)
+    kwargs.setdefault('charge', 0)
+    kwargs.setdefault('description', "")
+    kwargs.setdefault('filename', "")
+    kwargs.setdefault('hdf5_dir', None)
+
+    if (stytem_type=='molecule'):
+        if (build_type=='openfermion'):
+            my_system_skeleton = MA.OpenFermionMolAdapter(mol_geometry = kwargs['mol_geometry'],
+                                                          basis = kwargs['basis'],
+                                                          multiplicity = kwargs['multiplicity'],
+                                                          charge = kwargs['charge'],
+                                                          description = kwargs['description'],
+                                                          filename = kwargs['filename'],
+                                                          hdf5_dir = kwargs['hdf5_dir'])
+
+            return my_system_skeleton
+
+        else:
+            raise TypeError("build type not supported, supported type is 'open_fermion'.")
+
+    else:
+        raise TypeError("system type not supported, supported type is 'molecule'.")


### PR DESCRIPTION
This PR adds a Molecule and MolAdapter, and OpenFermionMolAdapter classes to qforte. The Molecule object attributes (such as the fci_energy, or poly word hamiltonian) can be generated using OpenFermionMolAdapter.