### PR TITLE
Fix import issues with latest version of openfermion

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -13,9 +13,11 @@ from qforte.system.molecular_info import Molecule
 from qforte.utils import transforms as tf
 
 from openfermion.ops import FermionOperator, QubitOperator
-from openfermion.hamiltonians import MolecularData
+from openfermion.chem import MolecularData
 from openfermion.transforms import get_fermion_operator, jordan_wigner
-from openfermion.utils import hermitian_conjugated, normal_ordered, freeze_orbitals
+from openfermion.transforms.opconversions import normal_ordered
+from openfermion.transforms.repconversions import freeze_orbitals
+from openfermion.utils import hermitian_conjugated
 
 from openfermionpsi4 import run_psi4
 


### PR DESCRIPTION
In the latest version of open fermion the path to several functions has changed and these changes are necessary just to import qforte.