### PR TITLE
Adds backward compatibility with openfermion v0.9.

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -13,11 +13,20 @@ from qforte.system.molecular_info import Molecule
 from qforte.utils import transforms as tf
 
 from openfermion.ops import FermionOperator, QubitOperator
-from openfermion.chem import MolecularData
+
+try:
+    from openfermion.chem import MolecularData
+except:
+    from openfermion.hamiltonians import MolecularData
+
 from openfermion.transforms import get_fermion_operator, jordan_wigner
-from openfermion.transforms.opconversions import normal_ordered
-from openfermion.transforms.repconversions import freeze_orbitals
-from openfermion.utils import hermitian_conjugated
+
+try:
+    from openfermion.transforms.opconversions import normal_ordered
+    from openfermion.transforms.repconversions import freeze_orbitals
+    from openfermion.utils import hermitian_conjugated
+except:
+    from openfermion.utils import hermitian_conjugated, normal_ordered, freeze_orbitals
 
 from openfermionpsi4 import run_psi4
 


### PR DESCRIPTION
Adds try, except statements to molecular_adapters.py in order to allow for backward compatibility with the file structure of openfermion version 0.9 (installable with anaconda).