### PR TITLE
QITE cleanup and Fix bugged S matrix

### DIFF
--- a/tests/qite_test.py
+++ b/tests/qite_test.py
@@ -76,7 +76,7 @@ class QITETests(unittest.TestCase):
         mol.set_sq_hamiltonian(H2_sq_hamiltonian)
 
         alg = QITE(mol, ref)
-        alg.run(beta=10.0, do_lanczos=True, lanczos_gap=49)
+        alg.run(beta=18.0, do_lanczos=True, lanczos_gap=49)
         Egs = alg.get_gs_energy()
         self.assertLess(abs(Egs-E_fci), 1.0e-10)
 


### PR DESCRIPTION
This PR started as some running cleanup in the QITE code, but I found a bug in the S matrix construction and figured I should submit what I have.

For some reason, the old code incorrectly assumed S[0, 1:] = S[1:, 0] = 0. I can only assume this was an indexing error, as there's nothing special theoretically about index 0. Sadly, making this change hurts convergence significantly, and I had to extend beta from 10 to 18(!) to not break tests. I'd be happy to learn I'm misunderstanding the method on this one. This is what happens when you use an 8x8 matrix to describe a one parameter electronic structure problem.