### PR TITLE
MRSQK Cleanup and Bugfix

### DIFF
--- a/tests/qite_test.py
+++ b/tests/qite_test.py
@@ -76,7 +76,7 @@ class QITETests(unittest.TestCase):
         mol.set_sq_hamiltonian(H2_sq_hamiltonian)
 
         alg = QITE(mol, ref)
-        alg.run(beta=10.0, do_lanczos=True, lanczos_gap=49)
+        alg.run(beta=18.0, do_lanczos=True, lanczos_gap=49)
         Egs = alg.get_gs_energy()
         self.assertLess(abs(Egs-E_fci), 1.0e-10)
 


### PR DESCRIPTION
This is another case where I was a cleaning up a method, then stumbled cross a bug, so I want to make the PR early. [This code](https://github.com/evangelistalab/qforte/blob/master/src/qforte/qkd/mrsqk.py#L617-L619) performs some normalization operation on `basis_coeff_vec_lst`, which is never used again. I believe this was supposed to be on `basis_coeff_mat`, which is used later. This PR eliminates `basis_coeff_vec_lst` in favor of `basis_coeff_mat`, so that error _cannot_ happen.

Please check that's correct. I'm still trying to figure out the "big picture" of the numerical linear algebra operations here.