### PR TITLE
Add note about passing cmake flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ cd qforte
 python setup.py develop
 ```
 
+To supply custom arguments to `cmake` for installation, you can either edit `setup.py` or `CMakeLists.txt`.
+
 #### run tests:
 ```bash
 python setup.py test


### PR DESCRIPTION
Created a note about how to pass different cmake flags to `qforte`. I needed to do this to get a successful compilation, so I figure it's worth including in the readme.