### PR TITLE
Error catching with frozen spaces

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -36,7 +36,7 @@ class Algorithm(ABC):
 
     _n_ham_measurements : int
         The total number of times the energy was evaluated via
-        measurement of the Hamiltoanin
+        measurement of the Hamiltonian
 
 
 
@@ -66,6 +66,8 @@ class Algorithm(ABC):
         self._Uprep = build_Uprep(reference, trial_state_type)
         # TODO (Nick): change Molecule.get_hamiltonian() to Molecule.get_qb_hamiltonain()
         self._qb_ham = system.get_hamiltonian()
+        if self._qb_ham.num_qubits() < self._nqb:
+            raise ValueError("The reference has more qubits than the Hamiltonian. Check your reference.")
         if hasattr(system, '_hf_energy'):
             self._hf_energy = system.get_hf_energy()
         else:

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -154,6 +154,8 @@ class OpenFermionMolAdapter(MolAdapter):
                 # We want to freeze virtuals but not core. Openfermion requires frozen_indices to be non-empty.
                 # As of 5/5/21, this is because freeze_orbitals assumes you can call "in" on the frozen_indices.
                 kwargs['frozen_indices'] = []
+            if any(x >= molecular_hamiltonian.n_qubits for x in kwargs['frozen_indices'] + kwargs['virtual_indices']):
+                raise ValueError(f"The orbitals to freeze are inconsistent with the fact that we only have {molecular_hamiltonian.n_qubits} qubits.")
 
             fermion_hamiltonian = normal_ordered(
                 freeze_orbitals(get_fermion_operator(molecular_hamiltonian),

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -62,7 +62,8 @@ PYBIND11_MODULE(qforte, m) {
         .def("simplify", &QuantumOperator::simplify)
         .def("operator_product", &QuantumOperator::operator_product)
         .def("check_op_equivalence", &QuantumOperator::check_op_equivalence)
-        .def("str", &QuantumOperator::str);
+        .def("str", &QuantumOperator::str)
+        .def("num_qubits", &QuantumOperator::num_qubits);
 
     py::class_<QuantumOpPool>(m, "QuantumOpPool")
         .def(py::init<>())

--- a/src/qforte/quantum_circuit.cc
+++ b/src/qforte/quantum_circuit.cc
@@ -124,6 +124,14 @@ std::string QuantumCircuit::str() const {
     return "[" + join(s, " ") + "]";
 }
 
+size_t QuantumCircuit::num_qubits() const {
+    size_t max = 0;
+    for (const auto& gate: gates_) {
+        max = std::max({max, gate.target() + 1, gate.control() + 1});
+    }
+    return max;
+}
+
 // std::vector<double> QuantumCircuit::get_parameters() {
 //     // need a loop over only gates in state preparation circuit that
 //     // have a parameter dependance (if gate_id == Rx, Ry, or Rz)

--- a/src/qforte/quantum_circuit.h
+++ b/src/qforte/quantum_circuit.h
@@ -47,6 +47,8 @@ class QuantumCircuit {
     /// return a vector of string representing this circuit
     std::string str() const;
 
+    size_t num_qubits() const;
+
   private:
     /// the list of gates
     std::vector<QuantumGate> gates_;

--- a/src/qforte/quantum_operator.cc
+++ b/src/qforte/quantum_operator.cc
@@ -155,3 +155,11 @@ std::string QuantumOperator::str() const {
     }
     return join(s, "\n");
 }
+
+size_t QuantumOperator::num_qubits() const {
+    size_t max = 0;
+    for (const auto& summand : terms_) {
+        max = std::max(max, summand.second.num_qubits());
+    }
+    return max;
+}

--- a/src/qforte/quantum_operator.h
+++ b/src/qforte/quantum_operator.h
@@ -60,6 +60,8 @@ class QuantumOperator {
     /// return a string representing this quantum operator
     std::string str() const;
 
+    size_t num_qubits() const;
+
   private:
     /// the linear combination of circuits
     std::vector<std::pair<std::complex<double>, QuantumCircuit>> terms_;

--- a/src/qforte/system/molecular_info.py
+++ b/src/qforte/system/molecular_info.py
@@ -95,9 +95,6 @@ class Molecule(object):
     def set_sq_of_ham(self, sq_of_ham):
         self._sq_of_ham = sq_of_ham
 
-    def set_nmo(self, nmo):
-        self._nmo = nmo
-
     def set_nel(self, nel):
         self._nel = nel
 

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -48,7 +48,7 @@ class UccTests(unittest.TestCase):
                                      basis='cc-pvdz',
                                      mol_geometry = [('He', (0, 0, 0))])
 
-        mol_adapter.run(virtual_indices=[9, 10])
+        mol_adapter.run(virtual_indices=[8, 9])
         mol = mol_adapter.get_molecule()
 
         ref = [1,1,0,0,0,0,0,0]


### PR DESCRIPTION
A rare PR from me that has a +LoC.

This PR catches a couple gotchas when using frozen virtuals: you can't freeze an orbital that doesn't exist, and you can't stuff more qubits in your reference than you have according to your Hamiltonian.