### PR TITLE
Remove references to unused mo_oei and mo_tei member variables

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -365,8 +365,6 @@ class Psi4MolAdapter(MolAdapter):
         self._qforte_mol.set_nuclear_repulsion_energy(p4_Enuc_ref)
         self._qforte_mol.set_hf_energy(p4_Escf)
         self._qforte_mol.set_hf_reference(hf_reference)
-        self._qforte_mol.set_mo_oei(mo_oeis)
-        self._qforte_mol.set_mo_tei(mo_teis)
         self._qforte_mol.set_sq_hamiltonian(Hsq)
         self._qforte_mol.set_hamiltonian(Hsq.jw_transform())
 

--- a/src/qforte/system/molecular_info.py
+++ b/src/qforte/system/molecular_info.py
@@ -101,12 +101,6 @@ class Molecule(object):
     def set_hf_reference(self, hf_reference):
         self._hf_reference = hf_reference
 
-    def set_mo_oei(self, oei):
-        self._mo_oei = oei
-
-    def set_mo_tei(self, tei):
-        self._mo_tei = tei
-
     def set_ccsd_amps(self, ccsd_singles, ccsd_doubles):
         self._ccsd_singles = ccsd_singles
         self._ccsd_doubles = ccsd_doubles


### PR DESCRIPTION
Exactly what it says in the title. Nick, was there some reason why these variables were added in the first place?