### PR TITLE
Simplified Molecule Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,7 @@ from qforte.system import system_factory
 H2geom = [('H', (0., 0., 0.)), ('H', (0., 0., 1.50))]
 H2ref = [1,1,0,0]
 
-adapter = system_factory(mol_geometry=H2geom)
-adapter.run()
-H2mol = adapter.get_molecule()
+H2mol = system_factory(mol_geometry=H2geom)
 
 alg = QPE(H2mol, H2ref, trotter_number=2)
 alg.run(t = 0.4,

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -64,10 +64,10 @@ class Algorithm(ABC):
         self._nqb = len(reference)
         self._trial_state_type = trial_state_type
         self._Uprep = build_Uprep(reference, trial_state_type)
-        # TODO (Nick): change Molecule.get_hamiltonian() to Molecule.get_qb_hamiltonain()
+        # TODO (Nick): change Molecule.get_hamiltonian() to Molecule.get_qb_hamiltonian()
         self._qb_ham = system.get_hamiltonian()
-        if self._qb_ham.num_qubits() < self._nqb:
-            raise ValueError("The reference has more qubits than the Hamiltonian. Check your reference.")
+        if self._qb_ham.num_qubits() != self._nqb:
+            raise ValueError(f"The reference has {self._nqb} qubits, but the Hamiltonian has {self._qb_ham.num_qubits()}. This is inconsistent.")
         if hasattr(system, '_hf_energy'):
             self._hf_energy = system.get_hf_energy()
         else:

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -222,7 +222,7 @@ def create_psi_mol(**kwargs):
     multiplicity = kwargs['multiplicity']
     charge = kwargs['charge']
 
-    self._qforte_mol = Molecule(mol_geometry = mol_geometry,
+    qforte_mol = Molecule(mol_geometry = mol_geometry,
                                basis = basis,
                                multiplicity = multiplicity,
                                charge = charge)
@@ -254,7 +254,7 @@ def create_psi_mol(**kwargs):
 
     scf_ref_type = "rhf" if multiplicity == 1 else "rohf"
 
-    psi4.set_options({'basis': self._basis,
+    psi4.set_options({'basis': basis,
               'scf_type': 'pk',
               'reference' : scf_ref_type,
               'e_convergence': 1e-8,
@@ -280,6 +280,7 @@ def create_psi_mol(**kwargs):
     mints = psi4.core.MintsHelper(p4_wfn.basisset())
 
     C = p4_wfn.Ca()
+
     scalars = p4_wfn.scalar_variables()
 
     p4_Enuc_ref = scalars["NUCLEAR REPULSION ENERGY"]

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -38,393 +38,342 @@ try:
 except:
     use_psi4 = False
 
-class MolAdapter(ABC):
-    """Abstract class for the aquiring system information from external electronic
-    structure calculations. The run() method calculates the desired properties and
-    data for the molecular system. Information is then stored in the
-    self._qforte_mol attribuite.
-    """
 
-    @abstractmethod
-    def run(self, **kwargs):
-        pass
-
-    @abstractmethod
-    def get_molecule(self):
-        pass
-
-
-class OpenFermionMolAdapter(MolAdapter):
-    """Class which builds a Molecule object using openfermion as a backend.
+def create_openfermion_mol(**kwargs):
+    """Builds a Molecule object using openfermion as a backend.
     By default, it runs a scf calcuation and stores the qubit hamiltonian
-    (hamiltonian in
-    poly word representation).
+    (hamiltonian in poly word representation).
 
-    Atributes
+    Variables
     ---------
-    _mol_geometry : list of tuples
+    mol_geometry : list of tuples
         Gives coordinates of each atom in Angstroms. Example format is
         geometry = [('H', (0., 0., 0.)), ('H', (0., 0., 1.50))]. It serves
         as an argument for the MolecularData class in openfermion.
 
-    _basis : string
+    basis : string
         Gives the basis set to be used. Default is 'sto-3g'. It serves
         as an argument for the MolecularData class in openfermion.
 
-    _multiplicity : int
+    multiplicity : int
         Gives the targeted spin multiplicity of the molecular system. It serves
         as an argument for the MolecularData class in openfermion.
 
-    _charge : int
+    charge : int
         Gives the targeted net charge of the molecular system (controls number of
         electrons to be considered). It serves as an argument for the
         MolecularData class in openfermion.
 
-    _description : optional, string
+    description : optional, string
         Recomeded to use to distingush various runs
         (for example with differnet bond lengths or geometric configurations).
 
-    _filename : optional, string
+    filename : optional, string
         Specifies the name of the .hdf5 file molecular data from psi4/pyscf
         calculation will be stored in.
 
-    _hdf5_dir : optional, string
+    hdf5_dir : optional, string
         Specifies the directory in which to store the .hdf5 file molecular
         data from psi4/pyscf calculation will be stored in.
         Default is "<openfermion_src_dir>/data".
 
-
-    _qforte_mol : Molecule
+    Returns
+    -------
+    Molecule
         The qforte Molecule object which holds the molecular information.
-
     """
 
-    def __init__(self, **kwargs):
-        self._mol_geometry = kwargs['mol_geometry']
-        self._basis = kwargs['basis']
-        self._multiplicity = kwargs['multiplicity']
-        self._charge = kwargs['charge']
-        self._description = kwargs['description']
-        self._filename = kwargs['filename']
-        self._hdf5_dir = kwargs['hdf5_dir']
+    qforte_mol = Molecule(mol_geometry = kwargs['mol_geometry'],
+                               basis = kwargs['basis'],
+                               multiplicity = kwargs['multiplicity'],
+                               charge = kwargs['charge'],
+                               description = kwargs['description'],
+                               filename = kwargs['filename'],
+                               hdf5_dir = kwargs['hdf5_dir'])
 
-        self._qforte_mol = Molecule(mol_geometry = kwargs['mol_geometry'],
-                                   basis = kwargs['basis'],
-                                   multiplicity = kwargs['multiplicity'],
-                                   charge = kwargs['charge'],
-                                   description = kwargs['description'],
-                                   filename = kwargs['filename'],
-                                   hdf5_dir = kwargs['hdf5_dir'])
+    kwargs.setdefault('order_sq_ham', False)
+    kwargs.setdefault('order_jw_ham', False)
+    kwargs.setdefault('run_scf', 1)
+    kwargs.setdefault('run_mp2', 0)
+    kwargs.setdefault('run_ccsd', 0)
+    kwargs.setdefault('run_cisd', 0)
+    kwargs.setdefault('run_cisd', 0)
+    kwargs.setdefault('run_fci', 1)
+    kwargs.setdefault('store_uccsd_amps', False)
+    kwargs.setdefault('frozen_indices', None)
+    kwargs.setdefault('virtual_indices', None)
 
-    def run(self, **kwargs):
+    skeleton_mol = MolecularData(geometry = kwargs["mol_geometry"],
+                                 basis = kwargs["basis"],
+                                 multiplicity = kwargs["multiplicity"],
+                                 charge = kwargs["charge"],
+                                 description = kwargs["description"],
+                                 filename = kwargs["filename"],
+                                 data_directory = kwargs["hdf5_dir"])
 
-        kwargs.setdefault('order_sq_ham', False)
-        kwargs.setdefault('order_jw_ham', False)
-        kwargs.setdefault('run_scf', 1)
-        kwargs.setdefault('run_mp2', 0)
-        kwargs.setdefault('run_ccsd', 0)
-        kwargs.setdefault('run_cisd', 0)
-        kwargs.setdefault('run_cisd', 0)
-        kwargs.setdefault('run_fci', 1)
-        kwargs.setdefault('store_uccsd_amps', False)
-        kwargs.setdefault('frozen_indices', None)
-        kwargs.setdefault('virtual_indices', None)
+    openfermion_mol = run_psi4(skeleton_mol, run_scf=kwargs['run_scf'],
+                                             run_mp2=kwargs['run_mp2'],
+                                             run_ccsd=kwargs['run_ccsd'],
+                                             run_cisd=kwargs['run_cisd'],
+                                             run_fci=kwargs['run_fci'])
 
-        skeleton_mol = MolecularData(geometry = self._mol_geometry,
-                                     basis = self._basis,
-                                     multiplicity = self._multiplicity,
-                                     charge = self._charge,
-                                     description = self._description,
-                                     filename = self._filename,
-                                     data_directory = self._hdf5_dir)
+    openfermion_mol.load()
 
-        openfermion_mol = run_psi4(skeleton_mol, run_scf=kwargs['run_scf'],
-                                                 run_mp2=kwargs['run_mp2'],
-                                                 run_ccsd=kwargs['run_ccsd'],
-                                                 run_cisd=kwargs['run_cisd'],
-                                                 run_fci=kwargs['run_fci'])
+    # Set qforte hamiltonian from openfermion
+    molecular_hamiltonian = openfermion_mol.get_molecular_hamiltonian()
 
-        openfermion_mol.load()
+    if(kwargs['frozen_indices'] is not None or kwargs['virtual_indices'] is not None):
+        if kwargs['frozen_indices'] is None:
+            # We want to freeze virtuals but not core. Openfermion requires frozen_indices to be non-empty.
+            # As of 5/5/21, this is because freeze_orbitals assumes you can call "in" on the frozen_indices.
+            kwargs['frozen_indices'] = []
+        if any(x >= molecular_hamiltonian.n_qubits for x in kwargs['frozen_indices'] + kwargs['virtual_indices']):
+            raise ValueError(f"The orbitals to freeze are inconsistent with the fact that we only have {molecular_hamiltonian.n_qubits} qubits.")
 
-        # Set qforte hamiltonian from openfermion
-        molecular_hamiltonian = openfermion_mol.get_molecular_hamiltonian()
+        fermion_hamiltonian = normal_ordered(
+            freeze_orbitals(get_fermion_operator(molecular_hamiltonian),
+                            kwargs['frozen_indices'],
+                            unoccupied=kwargs['virtual_indices']))
+    else:
+        fermion_hamiltonian = normal_ordered(get_fermion_operator(molecular_hamiltonian))
 
-        if(kwargs['frozen_indices'] is not None or kwargs['virtual_indices'] is not None):
-            if kwargs['frozen_indices'] is None:
-                # We want to freeze virtuals but not core. Openfermion requires frozen_indices to be non-empty.
-                # As of 5/5/21, this is because freeze_orbitals assumes you can call "in" on the frozen_indices.
-                kwargs['frozen_indices'] = []
-            if any(x >= molecular_hamiltonian.n_qubits for x in kwargs['frozen_indices'] + kwargs['virtual_indices']):
-                raise ValueError(f"The orbitals to freeze are inconsistent with the fact that we only have {molecular_hamiltonian.n_qubits} qubits.")
+    if(kwargs['order_sq_ham'] or kwargs['order_jw_ham']):
 
-            fermion_hamiltonian = normal_ordered(
-                freeze_orbitals(get_fermion_operator(molecular_hamiltonian),
-                                kwargs['frozen_indices'],
-                                unoccupied=kwargs['virtual_indices']))
-        else:
-            fermion_hamiltonian = normal_ordered(get_fermion_operator(molecular_hamiltonian))
+        if(kwargs['order_sq_ham'] and kwargs['order_jw_ham']):
+            raise ValueError("Can't use more than one hamiltonian ordering option!")
 
-        if(kwargs['order_sq_ham'] or kwargs['order_jw_ham']):
+        if(kwargs['order_sq_ham']):
+            # Optionally sort the hamiltonian terms
+            print('using |largest|->|smallest| sq hamiltonian ordering!')
+            sorted_terms = sorted(fermion_hamiltonian.terms.items(), key=lambda kv: np.abs(kv[1]), reverse=True)
 
-            if(kwargs['order_sq_ham'] and kwargs['order_jw_ham']):
-                raise ValueError("Can't use more than one hamiltonian ordering option!")
+            # Try converting with qforte jw functions
+            sorted_sq_excitations = tf.fermop_to_sq_excitation(sorted_terms)
+            sorted_organizer = tf.get_ucc_jw_organizer(sorted_sq_excitations, already_anti_herm=True)
+            qforte_hamiltonian = tf.organizer_to_circuit(sorted_organizer)
 
-            if(kwargs['order_sq_ham']):
-                # Optionally sort the hamiltonian terms
-                print('using |largest|->|smallest| sq hamiltonian ordering!')
-                sorted_terms = sorted(fermion_hamiltonian.terms.items(), key=lambda kv: np.abs(kv[1]), reverse=True)
+        if(kwargs['order_jw_ham']):
+            print('using |largest|->|smallest| jw hamiltonian ordering!')
+            unsorted_terms = [(k, v) for k, v in fermion_hamiltonian.terms.items()]
 
-                # Try converting with qforte jw functions
-                sorted_sq_excitations = tf.fermop_to_sq_excitation(sorted_terms)
-                sorted_organizer = tf.get_ucc_jw_organizer(sorted_sq_excitations, already_anti_herm=True)
-                qforte_hamiltonian = tf.organizer_to_circuit(sorted_organizer)
+            # Try converting with qforte jw functions
+            unsorted_sq_excitations = tf.fermop_to_sq_excitation(unsorted_terms)
+            # print('\nunsorted_sq_excitations:\n', unsorted_sq_excitations)
 
-            if(kwargs['order_jw_ham']):
-                print('using |largest|->|smallest| jw hamiltonian ordering!')
-                unsorted_terms = [(k, v) for k, v in fermion_hamiltonian.terms.items()]
+            unsorted_organizer = tf.get_ucc_jw_organizer(unsorted_sq_excitations, already_anti_herm=True)
+            # print('\nunsorted_organizer:\n', unsorted_organizer)
 
-                # Try converting with qforte jw functions
-                unsorted_sq_excitations = tf.fermop_to_sq_excitation(unsorted_terms)
-                # print('\nunsorted_sq_excitations:\n', unsorted_sq_excitations)
-
-                unsorted_organizer = tf.get_ucc_jw_organizer(unsorted_sq_excitations, already_anti_herm=True)
-                # print('\nunsorted_organizer:\n', unsorted_organizer)
-
-                # Sort organizer
-                sorted_organizer = sorted(unsorted_organizer, key = lambda x: np.abs(x[0]), reverse=True)
+            # Sort organizer
+            sorted_organizer = sorted(unsorted_organizer, key = lambda x: np.abs(x[0]), reverse=True)
 
 
-                qforte_hamiltonian = tf.organizer_to_circuit(sorted_organizer)
+            qforte_hamiltonian = tf.organizer_to_circuit(sorted_organizer)
 
-        else:
-            print('Using standard openfermion hamiltonian ordering!')
-            qubit_hamiltonian = jordan_wigner(fermion_hamiltonian)
-            qforte_hamiltonian = build_from_openfermion(qubit_hamiltonian)
+    else:
+        print('Using standard openfermion hamiltonian ordering!')
+        qubit_hamiltonian = jordan_wigner(fermion_hamiltonian)
+        qforte_hamiltonian = build_from_openfermion(qubit_hamiltonian)
 
-        self._qforte_mol.set_hamiltonian(qforte_hamiltonian)
+    qforte_mol.set_hamiltonian(qforte_hamiltonian)
 
-        self._qforte_mol.set_sq_hamiltonian( build_sqop_from_openfermion(fermion_hamiltonian) )
+    qforte_mol.set_sq_hamiltonian( build_sqop_from_openfermion(fermion_hamiltonian) )
 
-        self._qforte_mol.set_sq_of_ham(fermion_hamiltonian)
+    qforte_mol.set_sq_of_ham(fermion_hamiltonian)
 
-        # Set qforte energies from openfermion
-        if(kwargs['run_scf']):
-            self._qforte_mol.set_hf_energy(openfermion_mol.hf_energy)
+    # Set qforte energies from openfermion
+    if(kwargs['run_scf']):
+        qforte_mol.set_hf_energy(openfermion_mol.hf_energy)
 
-        if(kwargs['run_mp2']):
-            self._qforte_mol.set_mp2_energy(openfermion_mol.mp2_energy)
+    if(kwargs['run_mp2']):
+        qforte_mol.set_mp2_energy(openfermion_mol.mp2_energy)
 
-        if(kwargs['run_cisd']):
-            self._qforte_mol.set_cisd_energy(openfermion_mol.cisd_energy)
+    if(kwargs['run_cisd']):
+        qforte_mol.set_cisd_energy(openfermion_mol.cisd_energy)
 
-        if(kwargs['run_ccsd']):
-            self._qforte_mol.set_ccsd_energy(openfermion_mol.ccsd_energy)
+    if(kwargs['run_ccsd']):
+        qforte_mol.set_ccsd_energy(openfermion_mol.ccsd_energy)
 
-            # Store uccsd circuit with initial guess from ccsd amplitudes
-            if(kwargs['store_uccsd_amps']==True):
-                self._qforte_mol.set_ccsd_amps(openfermion_mol.ccsd_single_amps,
-                              openfermion_mol.ccsd_double_amps)
+        # Store uccsd circuit with initial guess from ccsd amplitudes
+        if(kwargs['store_uccsd_amps']==True):
+            qforte_mol.set_ccsd_amps(openfermion_mol.ccsd_single_amps,
+                          openfermion_mol.ccsd_double_amps)
 
-        if(kwargs['run_fci']):
-            self._qforte_mol.set_fci_energy(openfermion_mol.fci_energy)
+    if(kwargs['run_fci']):
+        qforte_mol.set_fci_energy(openfermion_mol.fci_energy)
+
+    return qforte_mol
 
 
-
-    def get_molecule(self):
-        return self._qforte_mol
-
-class Psi4MolAdapter(MolAdapter):
+def create_psi_mol(**kwargs):
     """Builds a qforte Molecule object directly from a psi4 calculation.
+
+    Returns
+    -------
+    Molecule
+        The qforte Molecule object which holds the molecular information.
     """
 
-    def __init__(self, **kwargs):
+    kwargs.setdefault('symmetry', 'c1')
+    kwargs.setdefault('charge', 0)
+    kwargs.setdefault('multiplicity', 1)
 
-        kwargs.setdefault('symmetry', 'c1')
-        kwargs.setdefault('charge', 0)
-        kwargs.setdefault('multiplicity', 1)
+    mol_geometry = kwargs['mol_geometry']
+    basis = kwargs['basis']
+    multiplicity = kwargs['multiplicity']
+    charge = kwargs['charge']
 
-        self._mol_geometry = kwargs['mol_geometry']
-        self._basis = kwargs['basis']
-        self._multiplicity = kwargs['multiplicity']
-        self._charge = kwargs['charge']
-        self._symmetry = kwargs['symmetry']
+    self._qforte_mol = Molecule(mol_geometry = mol_geometry,
+                               basis = basis,
+                               multiplicity = multiplicity,
+                               charge = charge)
 
-        self._qforte_mol = Molecule(mol_geometry = kwargs['mol_geometry'],
-                                   basis = kwargs['basis'],
-                                   multiplicity = kwargs['multiplicity'],
-                                   charge = kwargs['charge'])
+    if not use_psi4:
+        raise ImportError("Psi4 was not imported correctely.")
+
+    # run_scf is not read, because we always run SCF to get a wavefunction object.
+    kwargs.setdefault('run_mp2', 0)
+    kwargs.setdefault('run_ccsd', 0)
+    kwargs.setdefault('run_cisd', 0)
+    kwargs.setdefault('run_fci', 1)
+
+    # Setup psi4 calculation(s)
+    psi4.set_memory('2 GB')
+    psi4.core.set_output_file('output.dat', False)
+
+    p4_geom_str =  f"{int(charge)}  {int(multiplicity)}"
+    for geom_line in mol_geometry:
+        p4_geom_str += f"\n{geom_line[0]}  {geom_line[1][0]}  {geom_line[1][1]}  {geom_line[1][2]}"
+    p4_geom_str += f"\nsymmetry {kwargs['symmetry']}"
+    p4_geom_str += f"\nunits angstrom"
+
+    print(' ==> Psi4 geometry <==')
+    print('-------------------------')
+    print(p4_geom_str)
+
+    p4_mol = psi4.geometry(p4_geom_str)
+
+    scf_ref_type = "rhf" if multiplicity == 1 else "rohf"
+
+    psi4.set_options({'basis': self._basis,
+              'scf_type': 'pk',
+              'reference' : scf_ref_type,
+              'e_convergence': 1e-8,
+              'd_convergence': 1e-8,
+              'ci_maxiter': 100})
+
+    # run psi4 caclulation
+    p4_Escf, p4_wfn = psi4.energy('SCF', return_wfn=True)
+
+    if(kwargs['run_mp2']):
+        qforte_mol.set_mp2_energy(psi4.energy('MP2'))
+
+    if(kwargs['run_ccsd']):
+        qforte_mol.set_ccsd_energy(psi4.energy('CCSD'))
+
+    if(kwargs['run_cisd']):
+        qforte_mol.set_cisd_energy(psi4.energy('CISD'))
+
+    if(kwargs['run_fci']):
+        qforte_mol.set_fci_energy(psi4.energy('FCI'))
+
+    # Get integrals using MintsHelper.
+    mints = psi4.core.MintsHelper(p4_wfn.basisset())
+
+    C = p4_wfn.Ca()
+    scalars = p4_wfn.scalar_variables()
+
+    p4_Enuc_ref = scalars["NUCLEAR REPULSION ENERGY"]
+
+    # Do MO integral transformation
+    mo_teis = np.asarray(mints.mo_eri(C, C, C, C))
+    mo_oeis = np.asarray(mints.ao_kinetic()) + np.asarray(mints.ao_potential())
+    mo_oeis = np.einsum('uj,vi,uv', C, C, mo_oeis)
+
+    nmo = np.shape(mo_oeis)[0]
+    nalpha = p4_wfn.nalpha()
+    nbeta = p4_wfn.nbeta()
+    nel = nalpha + nbeta
+
+    # Make hf_reference
+    hf_reference = [1] * nel + [0] * (2 * nmo - nel)
+
+    # Build second quantized Hamiltonian
+    nmo = np.shape(mo_oeis)[0]
+    Hsq = qforte.SQOperator()
+    Hsq.add_term(p4_Enuc_ref, [])
+    for i in range(nmo):
+        ia = i*2
+        ib = i*2 + 1
+        for j in range(nmo):
+            ja = j*2
+            jb = j*2 + 1
+
+            Hsq.add_term(mo_oeis[i,j], [ia, ja])
+            Hsq.add_term(mo_oeis[i,j], [ib, jb])
+
+            for k in range(nmo):
+                ka = k*2
+                kb = k*2 + 1
+                for l in range(nmo):
+                    la = l*2
+                    lb = l*2 + 1
+
+                    if(ia!=jb and kb != la):
+                        Hsq.add_term( mo_teis[i,l,k,j]/2, [ia, jb, kb, la] ) # abba
+                    if(ib!=ja and ka!=lb):
+                        Hsq.add_term( mo_teis[i,l,k,j]/2, [ib, ja, ka, lb] ) # baab
+
+                    if(ia!=ja and ka!=la):
+                        Hsq.add_term( mo_teis[i,l,k,j]/2, [ia, ja, ka, la] ) # aaaa
+                    if(ib!=jb and kb!=lb):
+                        Hsq.add_term( mo_teis[i,l,k,j]/2, [ib, jb, kb, lb] ) # bbbb
+
+    # Set attributes
+    qforte_mol.set_nuclear_repulsion_energy(p4_Enuc_ref)
+    qforte_mol.set_hf_energy(p4_Escf)
+    qforte_mol.set_hf_reference(hf_reference)
+    qforte_mol.set_sq_hamiltonian(Hsq)
+    qforte_mol.set_hamiltonian(Hsq.jw_transform())
+
+    return qforte_mol
 
 
-    def run(self, **kwargs):
-
-        if not use_psi4:
-            raise ImportError("Psi4 was not imported correctely.")
-
-        # run_scf is not read, because we always run SCF to get a wavefunction object.
-        kwargs.setdefault('run_mp2', 0)
-        kwargs.setdefault('run_ccsd', 0)
-        kwargs.setdefault('run_cisd', 0)
-        kwargs.setdefault('run_fci', 1)
-
-        # Setup psi4 calculation(s)
-        psi4.set_memory('2 GB')
-        psi4.core.set_output_file('output.dat', False)
-
-        p4_geom_str =  f"{int(self._charge)}  {int(self._multiplicity)}"
-        for geom_line in self._mol_geometry:
-            p4_geom_str += f"\n{geom_line[0]}  {geom_line[1][0]}  {geom_line[1][1]}  {geom_line[1][2]}"
-        p4_geom_str += f"\nsymmetry {self._symmetry}"
-        p4_geom_str += f"\nunits angstrom"
-
-        print(' ==> Psi4 geometry <==')
-        print('-------------------------')
-        print(p4_geom_str)
-
-        p4_mol = psi4.geometry(p4_geom_str)
-
-        if self._multiplicity == 1:
-            scf_ref_type = 'rhf'
-        else:
-            scf_ref_type = 'rohf'
-
-        psi4.set_options({'basis': self._basis,
-                  'scf_type': 'pk',
-                  'reference' : scf_ref_type,
-                  'e_convergence': 1e-8,
-                  'd_convergence': 1e-8,
-                  'ci_maxiter': 100})
-
-        # run psi4 caclulation
-        p4_Escf, p4_wfn = psi4.energy('SCF', return_wfn=True)
-
-        if(kwargs['run_mp2']):
-            p4_Emp2 = psi4.energy('MP2')
-
-        if(kwargs['run_ccsd']):
-            p4_Eccsd = psi4.energy('CCSD')
-
-        if(kwargs['run_ccsd']):
-            p4_Ecisd = psi4.energy('CISD')
-
-        if(kwargs['run_fci']):
-            p4_Efci = psi4.energy('FCI')
-
-        # Get integrals using MintsHelper.
-        mints = psi4.core.MintsHelper(p4_wfn.basisset())
-
-        C = p4_wfn.Ca()
-        scalars = p4_wfn.scalar_variables()
-
-        p4_Enuc_ref = scalars["NUCLEAR REPULSION ENERGY"]
-
-        # Do MO integral transformation
-        mo_teis = np.asarray(mints.mo_eri(C, C, C, C))
-        mo_oeis = np.asarray(mints.ao_kinetic()) + np.asarray(mints.ao_potential())
-        mo_oeis = np.einsum('uj,vi,uv', C, C, mo_oeis)
-
-        nmo = np.shape(mo_oeis)[0]
-        nalpha = p4_wfn.nalpha()
-        nbeta = p4_wfn.nbeta()
-        nel = nalpha + nbeta
-
-        # Make hf_reference
-        hf_reference = [1] * nel + [0] * (2 * nmo - nel)
-
-        # Build second quantized Hamiltonian
-        nmo = np.shape(mo_oeis)[0]
-        Hsq = qforte.SQOperator()
-        Hsq.add_term(p4_Enuc_ref, [])
-        for i in range(nmo):
-            ia = i*2
-            ib = i*2 + 1
-            for j in range(nmo):
-                ja = j*2
-                jb = j*2 + 1
-
-                Hsq.add_term(mo_oeis[i,j], [ia, ja])
-                Hsq.add_term(mo_oeis[i,j], [ib, jb])
-
-                for k in range(nmo):
-                    ka = k*2
-                    kb = k*2 + 1
-                    for l in range(nmo):
-                        la = l*2
-                        lb = l*2 + 1
-
-                        if(ia!=jb and kb != la):
-                            Hsq.add_term( mo_teis[i,l,k,j]/2, [ia, jb, kb, la] ) # abba
-                        if(ib!=ja and ka!=lb):
-                            Hsq.add_term( mo_teis[i,l,k,j]/2, [ib, ja, ka, lb] ) # baab
-
-                        if(ia!=ja and ka!=la):
-                            Hsq.add_term( mo_teis[i,l,k,j]/2, [ia, ja, ka, la] ) # aaaa
-                        if(ib!=jb and kb!=lb):
-                            Hsq.add_term( mo_teis[i,l,k,j]/2, [ib, jb, kb, lb] ) # bbbb
-
-        # Set attributes
-        self._qforte_mol.set_nuclear_repulsion_energy(p4_Enuc_ref)
-        self._qforte_mol.set_hf_energy(p4_Escf)
-        self._qforte_mol.set_hf_reference(hf_reference)
-        self._qforte_mol.set_sq_hamiltonian(Hsq)
-        self._qforte_mol.set_hamiltonian(Hsq.jw_transform())
-
-        if(kwargs['run_mp2']):
-            self._qforte_mol.set_mp2_energy(p4_Emp2)
-
-        if(kwargs['run_cisd']):
-            self._qforte_mol.set_cisd_energy(p4_Ecisd)
-
-        if(kwargs['run_ccsd']):
-            self._qforte_mol.set_ccsd_energy(p4_Eccsd)
-
-        if(kwargs['run_fci']):
-            self._qforte_mol.set_fci_energy(p4_Efci)
-
-    def get_molecule(self):
-        return self._qforte_mol
-
-class ExternalMolAdapter(MolAdapter):
+def create_external_mol(**kwargs):
     """Builds a qforte Molecule object from an external json file containing
     the one and two electron integrals and numbers of alpha/beta electrons.
+
+    Returns
+    -------
+    Molecule
+        The qforte Molecule object which holds the molecular information.
     """
 
-    def __init__(self, **kwargs):
-        # self._basis = kwargs['basis']
-        self._multiplicity = kwargs['multiplicity']
-        self._charge = kwargs['charge']
-        self._filename = kwargs['filename']
+    qforte_mol = Molecule(multiplicity = kwargs['multiplicity'],
+                                charge = kwargs['charge'],
+                                filename = kwargs['filename'])
 
+    # open json file
+    with open(kwargs["filename"]) as f:
+        external_data = json.load(f)
 
-        self._qforte_mol = Molecule(multiplicity = kwargs['multiplicity'],
-                                    charge = kwargs['charge'],
-                                    filename = kwargs['filename'])
+    # build sq hamiltonian
+    qforte_sq_hamiltonian = qforte.SQOperator()
+    qforte_sq_hamiltonian.add_term(external_data['scalar_energy']['data'], [])
 
-    def run(self, **kwargs):
+    for p, q, h_pq in external_data['oei']['data']:
+        qforte_sq_hamiltonian.add_term(h_pq, [p,q])
 
-        # open json file
-        with open(self._filename) as f:
-            external_data = json.load(f)
+    for p, q, r, s, h_pqrs in external_data['tei']['data']:
+        qforte_sq_hamiltonian.add_term(h_pqrs/4.0, [p,q,s,r]) # only works in C1 symmetry
 
-        # build sq hamiltonain
-        qforte_sq_hamiltonian = qforte.SQOperator()
-        qforte_sq_hamiltonian.add_term(external_data['scalar_energy']['data'], [])
+    hf_reference = [0 for i in range(external_data['nso']['data'])]
+    for n in range(external_data['na']['data'] + external_data['nb']['data']):
+        hf_reference[n] = 1
 
-        for p, q, h_pq in external_data['oei']['data']:
-            qforte_sq_hamiltonian.add_term(h_pq, [p,q])
+    qforte_mol.set_hf_reference(hf_reference)
 
-        for p, q, r, s, h_pqrs in external_data['tei']['data']:
-            qforte_sq_hamiltonian.add_term(h_pqrs/4.0, [p,q,s,r]) # only works in C1 symmetry
+    qforte_mol.set_sq_hamiltonian(qforte_sq_hamiltonian)
 
-        hf_reference = [0 for i in range(external_data['nso']['data'])]
-        for n in range(external_data['na']['data'] + external_data['nb']['data']):
-            hf_reference[n] = 1
+    qforte_mol.set_hamiltonian(qforte_sq_hamiltonian.jw_transform())
 
-        self._qforte_mol.set_hf_reference(hf_reference)
-
-        self._qforte_mol.set_sq_hamiltonian(qforte_sq_hamiltonian)
-
-        self._qforte_mol.set_hamiltonian(qforte_sq_hamiltonian.jw_transform())
-
-
-    def get_molecule(self):
-        return self._qforte_mol
+    return qforte_mol

--- a/src/qforte/system/system_factory.py
+++ b/src/qforte/system/system_factory.py
@@ -7,15 +7,13 @@ def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwarg
 
         Arguments
         ---------
-        system_type : string
+        system_type : {"molecule"}
             Gives the type of system object to return.
 
-        build_type : string
-            Gives the method used to construct the system object. For example,
-            one could use OpenFermion, or one could just port directly from
-            Psi4 or pyscf.
+        build_type : {"openfermion", "external", "psi4"}
+            Specifies the adapter used to build the system.
 
-        Retruns
+        Returns
         -------
         my_sys_skeleton : MolAdapter
             A molecular/hubbard/jellium... adapter object which can be used to
@@ -31,9 +29,9 @@ def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwarg
     kwargs.setdefault('hdf5_dir', None)
 
     adapters = {
-        "openfermion": MA.OpenFermionMolAdapter,
-        "external": MA.ExternalMolAdapter,
-        "psi4": MA.Psi4MolAdapter
+        "openfermion": MA.create_openfermion_mol,
+        "external": MA.create_external_mol,
+        "psi4": MA.create_psi_mol
     }
 
     if (system_type=='molecule'):
@@ -42,9 +40,7 @@ def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwarg
         except:
             raise TypeError(f"build type {build_type} not supported, supported types are: " + ", ".join(adapters.keys()))
 
-        my_system_skeleton = adapter(**kwargs)
-
     else:
         raise TypeError("system type not supported, supported type is 'molecule'.")
 
-    return my_system_skeleton
+    return adapter(**kwargs)

--- a/tests/adapt_vqe_test.py
+++ b/tests/adapt_vqe_test.py
@@ -18,13 +18,10 @@ class ADAPTVQETests(unittest.TestCase):
         # The Nuclear repulsion energy
         Enuc =  3.057468328315556
 
-        mol_adapter = system_factory(stytem_type = 'molecule',
+        mol = system_factory(stytem_type = 'molecule',
                                      build_type = 'external',
                                      basis='sto-6g',
                                      filename=data_path)
-
-        mol_adapter.run()
-        mol = mol_adapter.get_molecule()
 
         ref = [1, 1, 1, 1, 0, 0, 0, 0]
 

--- a/tests/spqe_test.py
+++ b/tests/spqe_test.py
@@ -18,13 +18,11 @@ class SPQETests(unittest.TestCase):
         # The Nuclear repulsion energy
         Enuc =  3.057468328315556
 
-        mol_adapter = system_factory(stytem_type = 'molecule',
+        mol = system_factory(stytem_type = 'molecule',
                                      build_type = 'external',
                                      basis='sto-6g',
                                      filename=data_path)
 
-        mol_adapter.run()
-        mol = mol_adapter.get_molecule()
         Hnonzero = qforte.QuantumOperator()
         for term in mol._hamiltonian.terms():
             if abs(term[0]) > 1.0e-14:

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -33,6 +33,29 @@ class UccTests(unittest.TestCase):
         Egs = Egs_elec + Enuc
         self.assertLess(abs(Egs-Efci), 1.0e-11)
 
+    def test_He_uccsd_vqe_exact_psi(self):
+        print('\n')
+        # The FCI energy for He atom in a cc-pvdz basis
+        Efci = -2.887594831090938
+        # The Nuclear repulsion energy
+        Enuc =  0.0
+
+        mol = system_factory(system_type = 'molecule',
+                                     build_type = 'psi4',
+                                     basis='cc-pvdz',
+                                     mol_geometry = [('He', (0, 0, 0))],
+                                     filename=data_path)
+
+        ref = [1,1,0,0,0,0,0,0,0,0]
+
+        alg = UCCNVQE(mol, ref)
+        alg.run(pool_type = 'SD',
+                use_analytic_grad = True)
+
+        Egs_elec = alg.get_gs_energy()
+        Egs = Egs_elec + Enuc
+        self.assertLess(abs(Egs-Efci), 1.0e-11)
+
     def test_He_uccsd_vqe_frozen_virtual(self):
         print('\n')
         # The FCI energy for He atom in a cc-pvdz basis, according to Psi, one frozen virtual

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -18,13 +18,10 @@ class UccTests(unittest.TestCase):
         # The Nuclear repulsion energy
         Enuc =  0.0
 
-        mol_adapter = system_factory(system_type = 'molecule',
+        mol = system_factory(system_type = 'molecule',
                                      build_type = 'external',
                                      basis='cc-pvdz',
                                      filename=data_path)
-
-        mol_adapter.run()
-        mol = mol_adapter.get_molecule()
 
         ref = [1,1,0,0,0,0,0,0,0,0]
 
@@ -43,13 +40,11 @@ class UccTests(unittest.TestCase):
         # The Nuclear repulsion energy
         Enuc =  0.0
 
-        mol_adapter = system_factory(system_type = 'molecule',
+        mol = system_factory(system_type = 'molecule',
                                      build_type = 'openfermion',
                                      basis='cc-pvdz',
-                                     mol_geometry = [('He', (0, 0, 0))])
-
-        mol_adapter.run(virtual_indices=[8, 9])
-        mol = mol_adapter.get_molecule()
+                                     mol_geometry = [('He', (0, 0, 0))],
+                                     virtual_indices = [8, 9])
 
         ref = [1,1,0,0,0,0,0,0]
 
@@ -61,7 +56,6 @@ class UccTests(unittest.TestCase):
         Egs = Egs_elec + Enuc
         self.assertLess(abs(Egs-Efci), 1.0e-10)
 
-
     def test_He_uccsd_pqe_exact(self):
         print('\n')
         # The FCI energy for He atom in a cc-pvdz basis
@@ -69,13 +63,10 @@ class UccTests(unittest.TestCase):
         # The Nuclear repulsion energy
         Enuc =  0.0
 
-        mol_adapter = system_factory(system_type = 'molecule',
+        mol = system_factory(system_type = 'molecule',
                                      build_type = 'external',
                                      basis='cc-pvdz',
                                      filename=data_path)
-
-        mol_adapter.run()
-        mol = mol_adapter.get_molecule()
 
         ref = [1,1,0,0,0,0,0,0,0,0]
 


### PR DESCRIPTION
This PR closes #70 and is API-breaking.

In the old API, `system_factory` would return a `molecule_adapter` object, the object's `run` method would be called, and then its `get_molecule` method would be called. The `molecule_adapter` object is good for absolutely nothing else. This PR streamlines the procedure: The various `molecule_adapter` objects are now just functions that return a molecule. The associated class hierarchy is gone, and this three-step procedure to create a molecule is reduced to just one.