### PR TITLE
Psi4 is now symmetry-compatible

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -279,7 +279,7 @@ def create_psi_mol(**kwargs):
     # Get integrals using MintsHelper.
     mints = psi4.core.MintsHelper(p4_wfn.basisset())
 
-    C = p4_wfn.Ca()
+    C = p4_wfn.Ca_subset("AO", "ALL")
 
     scalars = p4_wfn.scalar_variables()
 

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -44,7 +44,8 @@ class UccTests(unittest.TestCase):
                                      build_type = 'psi4',
                                      basis='cc-pvdz',
                                      mol_geometry = [('He', (0, 0, 0))],
-                                     filename=data_path)
+                                     filename=data_path,
+                                     symmetry = "c2v")
 
         ref = [1,1,0,0,0,0,0,0,0,0]
 


### PR DESCRIPTION
Closes #76 and knocks off an item on @fevangelista's wishlist: it's now possible to tell Psi4 to use symmetry for its own computations! QForte doesn't take advantage of this at present, but at least now it _can_ use orbitals from a computation with symmetry.

This also amends the recent Psi4 molecule test case to employ symmetry.