### PR TITLE
Removes need for user defined reference list.

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -51,7 +51,7 @@ class Algorithm(ABC):
 
     def __init__(self,
                  system,
-                 reference,
+                 reference=None,
                  trial_state_type='reference',
                  trotter_order=1,
                  trotter_number=1,
@@ -60,10 +60,14 @@ class Algorithm(ABC):
                  print_summary_file=False):
 
         self._sys = system
-        self._ref = reference
-        self._nqb = len(reference)
+        if(reference==None):
+            self._ref = system.get_hf_reference()
+        else:
+            self._ref = reference
+
+        self._nqb = len(self._ref)
         self._trial_state_type = trial_state_type
-        self._Uprep = build_Uprep(reference, trial_state_type)
+        self._Uprep = build_Uprep(self._ref, trial_state_type)
         # TODO (Nick): change Molecule.get_hamiltonian() to Molecule.get_qb_hamiltonian()
         self._qb_ham = system.get_hamiltonian()
         if self._qb_ham.num_qubits() != self._nqb:

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -134,8 +134,13 @@ def create_openfermion_mol(**kwargs):
             freeze_orbitals(get_fermion_operator(molecular_hamiltonian),
                             kwargs['frozen_indices'],
                             unoccupied=kwargs['virtual_indices']))
+
+        hf_reference = [1] * (openfermion_mol.n_electrons - len(kwargs['frozen_indices'])) + [0] * (openfermion_mol.n_qubits - openfermion_mol.n_electrons - len(kwargs['virtual_indices']))
+
     else:
         fermion_hamiltonian = normal_ordered(get_fermion_operator(molecular_hamiltonian))
+
+        hf_reference = [1] * openfermion_mol.n_electrons + [0] * (openfermion_mol.n_qubits - openfermion_mol.n_electrons)
 
     if(kwargs['order_sq_ham'] or kwargs['order_jw_ham']):
 
@@ -171,13 +176,13 @@ def create_openfermion_mol(**kwargs):
 
     else:
         print('Using standard openfermion hamiltonian ordering!')
+
         qubit_hamiltonian = jordan_wigner(fermion_hamiltonian)
         qforte_hamiltonian = build_from_openfermion(qubit_hamiltonian)
 
+    qforte_mol.set_hf_reference(hf_reference)
     qforte_mol.set_hamiltonian(qforte_hamiltonian)
-
     qforte_mol.set_sq_hamiltonian( build_sqop_from_openfermion(fermion_hamiltonian) )
-
     qforte_mol.set_sq_of_ham(fermion_hamiltonian)
 
     # Set qforte energies from openfermion

--- a/tests/adapt_vqe_test.py
+++ b/tests/adapt_vqe_test.py
@@ -23,9 +23,8 @@ class ADAPTVQETests(unittest.TestCase):
                                      basis='sto-6g',
                                      filename=data_path)
 
-        ref = [1, 1, 1, 1, 0, 0, 0, 0]
+        alg = ADAPTVQE(mol, print_summary_file=False)
 
-        alg = ADAPTVQE(mol, ref, print_summary_file=False)
         alg.run(adapt_maxiter=20,
                 avqe_thresh=1.0e-4,
                 opt_thresh=1.0e-5,

--- a/tests/fast_qk_test.py
+++ b/tests/fast_qk_test.py
@@ -396,13 +396,13 @@ class QKDTests(unittest.TestCase):
         mol.set_hamiltonian(H4_qubit_hamiltonian)
 
         MRSQK
-        alg2 = MRSQK(mol, ref, trotter_number=100)
+        alg2 = MRSQK(mol, reference=ref, trotter_number=100)
         alg2.run(s=3, d=3)
         Egs2 = alg2.get_gs_energy()
         self.assertLess(abs(Egs2-E_fci), 1.0e-6)
 
         SRQK
-        alg1 = SRQK(mol, ref, trotter_number=100)
+        alg1 = SRQK(mol, reference=ref, trotter_number=100)
         alg1.run(s=6)
         Egs1 = alg1.get_gs_energy()
         self.assertLess(abs(Egs1-E_fci), 1.0e-4)

--- a/tests/qite_test.py
+++ b/tests/qite_test.py
@@ -75,7 +75,7 @@ class QITETests(unittest.TestCase):
         mol.set_hamiltonian(H2_qubit_hamiltonian)
         mol.set_sq_hamiltonian(H2_sq_hamiltonian)
 
-        alg = QITE(mol, ref)
+        alg = QITE(mol, reference=ref)
         alg.run(beta=18.0, do_lanczos=True, lanczos_gap=49)
         Egs = alg.get_gs_energy()
         self.assertLess(abs(Egs-E_fci), 1.0e-10)

--- a/tests/qpea_test.py
+++ b/tests/qpea_test.py
@@ -55,7 +55,7 @@ class QPETests(unittest.TestCase):
         mol = Molecule()
         mol.set_hamiltonian(H2_qubit_hamiltonian)
 
-        alg = QPE(mol, ref, trotter_number=2)
+        alg = QPE(mol, reference=ref, trotter_number=2)
         alg.run(t = 0.4,
                 nruns = 100,
                 success_prob = 0.5,

--- a/tests/slow_qk_test.py
+++ b/tests/slow_qk_test.py
@@ -396,7 +396,7 @@ class PhysicalQKDTests(unittest.TestCase):
         mol.set_hamiltonian(H4_qubit_hamiltonian)
 
         # SRQK
-        alg1 = SRQK(mol, ref, trotter_number=1, fast=False)
+        alg1 = SRQK(mol, reference=ref, trotter_number=1, fast=False)
         alg1.run(s=3)
         Egs1 = alg1.get_gs_energy()
 

--- a/tests/spqe_test.py
+++ b/tests/spqe_test.py
@@ -30,9 +30,7 @@ class SPQETests(unittest.TestCase):
         mol._hamiltonian = Hnonzero
         qforte.smart_print(Hnonzero)
 
-        ref = [1, 1, 1, 1, 0, 0, 0, 0]
-
-        alg = SPQE(mol, ref, print_summary_file=False)
+        alg = SPQE(mol, print_summary_file=False)
         alg.run(spqe_maxiter=20,
                 spqe_thresh=1.0e-4,
                 res_vec_thresh=1.0e-5,

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -23,9 +23,8 @@ class UccTests(unittest.TestCase):
                                      basis='cc-pvdz',
                                      filename=data_path)
 
-        ref = [1,1,0,0,0,0,0,0,0,0]
 
-        alg = UCCNVQE(mol, ref)
+        alg = UCCNVQE(mol)
         alg.run(pool_type = 'SD',
                 use_analytic_grad = True)
 
@@ -47,9 +46,7 @@ class UccTests(unittest.TestCase):
                                      filename=data_path,
                                      symmetry = "c2v")
 
-        ref = [1,1,0,0,0,0,0,0,0,0]
-
-        alg = UCCNVQE(mol, ref)
+        alg = UCCNVQE(mol)
         alg.run(pool_type = 'SD',
                 use_analytic_grad = True)
 
@@ -70,9 +67,7 @@ class UccTests(unittest.TestCase):
                                      mol_geometry = [('He', (0, 0, 0))],
                                      virtual_indices = [8, 9])
 
-        ref = [1,1,0,0,0,0,0,0]
-
-        alg = UCCNVQE(mol, ref)
+        alg = UCCNVQE(mol)
         alg.run(pool_type = 'SD',
                 use_analytic_grad = True)
 
@@ -92,9 +87,7 @@ class UccTests(unittest.TestCase):
                                      basis='cc-pvdz',
                                      filename=data_path)
 
-        ref = [1,1,0,0,0,0,0,0,0,0]
-
-        alg = UCCNPQE(mol, ref)
+        alg = UCCNPQE(mol)
         alg.run(pool_type = 'SD',
                 res_vec_thresh = 1.0e-7)
 


### PR DESCRIPTION
This PR removes the need for the user to specify and pass a reference list (list of 1's and 0's that usually defines the hartree fock state), it is minorly API breaking. The reference list is now automatically generated in the functions that build the molecule objects, but it is still possible to use a specified reference list by passing one. Test cases have been updated to reflect the new API.