### PR TITLE
Cleanup UCC

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -137,3 +137,30 @@ class Algorithm(ABC):
 
         if self._n_pauli_trm_measures is None:
             raise NotImplementedError('Concrete Algorithm class must define self._n_pauli_trm_measures attribute.')
+
+class AnsatzAlgorithm(Algorithm):
+    """
+    Attributes
+    ----------
+    _curr_energy: float
+        The energy at the current iteration step.
+    """
+
+    @abstractmethod
+    def build_Uvqc(self):
+        pass
+
+    @abstractmethod
+    def measure_energy(self):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._curr_energy = 0
+
+    def energy_feval(self, params):
+        Ucirc = self.build_Uvqc(amplitudes=params)
+        Energy = self.measure_energy(Ucirc)
+
+        self._curr_energy = Energy
+        return Energy

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -150,9 +150,24 @@ class AnsatzAlgorithm(Algorithm):
     def build_Uvqc(self):
         pass
 
-    @abstractmethod
-    def measure_energy(self):
-        pass
+    def measure_energy(self, Ucirc):
+        """
+        Parameters
+        ----------
+        Ucirc : QuantumCircuit
+            The state preparation circuit.
+        """
+        if self._fast:
+            myQC = qforte.QuantumComputer(self._nqb)
+            myQC.apply_circuit(Ucirc)
+            val = np.real(myQC.direct_op_exp_val(self._qb_ham))
+        else:
+            Exp = qforte.Experiment(self._nqb, Ucirc, self._qb_ham, 2000)
+            val = Exp.perfect_experimental_avg([])
+
+        assert np.isclose(np.imag(val), 0.0)
+
+        return val
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -1,0 +1,38 @@
+import qforte as qf
+from abc import ABC
+
+from qforte.utils.trotterization import trotterize
+
+class Ansatz(ABC):
+    pass
+
+class UCC(Ansatz):
+
+    def __init__(self, trotter_number, amplitudes, operators, pool):
+        self._trotter_number = trotter_number
+        self._tamps = amplitudes
+        self._tops = operators
+        self._pool = pool
+
+    def ansatz_circuit(self, amplitudes=None):
+        """ This function returns the QuantumCircuit object built
+        from the appropriate amplitudes (tops)
+
+        Parameters
+        ----------
+        amplitudes : list
+            A list of parameters that define the variational degrees of freedom in
+            the state preparation circuit Uvqc. This is needed for the scipy minimizer.
+        """
+        temp_pool = qf.SQOpPool()
+        tamps = self._tamps if amplitudes is None else amplitudes
+        for tamp, top in zip(tamps, self._tops):
+            temp_pool.add_term(tamp, self._pool[top][1])
+
+        A = temp_pool.get_quantum_operator('commuting_grp_lex')
+
+        U, phase1 = trotterize(A, trotter_number=self._trotter_number)
+        if phase1 != 1.0 + 0.0j:
+            raise ValueError("Encountered phase change, phase not equal to (1.0 + 0.0i)")
+        return U
+

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -1,18 +1,9 @@
 import qforte as qf
-from abc import ABC
+from qforte.abc.algorithm import AnsatzAlgorithm
 
 from qforte.utils.trotterization import trotterize
 
-class Ansatz(ABC):
-    pass
-
-class UCC(Ansatz):
-
-    def __init__(self, trotter_number, amplitudes, operators, pool):
-        self._trotter_number = trotter_number
-        self._tamps = amplitudes
-        self._tops = operators
-        self._pool = pool
+class UCC(AnsatzAlgorithm):
 
     def ansatz_circuit(self, amplitudes=None):
         """ This function returns the QuantumCircuit object built

--- a/src/qforte/abc/pqeabc.py
+++ b/src/qforte/abc/pqeabc.py
@@ -1,37 +1,15 @@
 from abc import abstractmethod
-from qforte.abc.algorithm import Algorithm
+from qforte.abc.algorithm import AnsatzAlgorithm
 
-class PQE(Algorithm):
-
-    @abstractmethod
-    def build_Uvqc(self):
-        pass
-
-    @abstractmethod
-    def measure_energy(self):
-        pass
-
-    @abstractmethod
-    def energy_feval(self):
-        pass
+class PQE(AnsatzAlgorithm):
 
     @abstractmethod
     def solve(self):
         pass
 
     def verify_required_PQE_attributes(self):
-        # if not hasattr(self, '_optimizer'):
-        #     raise NotImplementedError('Concrete PQE class must define self._optimizer attribute.')
-
         if not hasattr(self, '_converged'):
             raise NotImplementedError('Concrete PQE class must define self._converged attribute.')
-
-        # if not hasattr(self, '_final_result'):
-        #     raise NotImplementedError('Concrete PQE class must define self._final_result attribute.')
-
-        # if self._opt_maxiter is None:
-        #     if self._diis_maxiter is None:
-        #         raise NotImplementedError('Concrete PQE class must define self._diis_maxiter OR self._opt_maxiter attribute.')
 
         if not hasattr(self, '_opt_maxiter'):
             if not hasattr(self, '_diis_maxiter'):

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -1,6 +1,5 @@
 import qforte as qf
 from abc import abstractmethod
-# from qforte.abc.vqeabc import VQE
 from qforte.abc.pqeabc import PQE
 from qforte.utils.op_pools import *
 
@@ -33,213 +32,35 @@ class UCCPQE(PQE):
         self._curr_energy = 0.0
         self._curr_grad_norm = 0.0
 
-        self._Nm = []
-        for m in range(len(self._pool_obj.terms())):
-            self._Nm.append(len(self._pool_obj.terms()[m][1].jw_transform().terms()))
+        self._Nm = [len(operator.jw_transform().terms()) for _, operator in self._pool_obj.terms()]
 
     # TODO (opt major): write a C function that prepares this super efficiently
-    def build_Uvqc(self, params=None):
+    def build_Uvqc(self, amplitudes=None):
         """ This function returns the QuantumCircuit object built
-        from the appropiate ampltudes (tops)
+        from the appropiate amplitudes (tops)
 
         Parameters
         ----------
-        params : list
-            A list of parameters define the variational degress of freedom in
-            the state preparation circuit Uvqc.
+        amplitudes : list
+            A list of parameters that define the variational degrees of freedom in
+            the state preparation circuit Uvqc. This is needed for the scipy minimizer.
         """
         temp_pool = qf.SQOpPool()
-        if params is None:
-            for tamp, top in zip(self._tamps, self._tops):
-                temp_pool.add_term(tamp, self._pool[top][1])
-        else:
-            for param, top in zip(params, self._tops):
-                temp_pool.add_term(param, self._pool[top][1])
+        tamps = self._tamps if amplitudes is None else amplitudes
+        for tamp, top in zip(tamps, self._tops):
+            temp_pool.add_term(tamp, self._pool[top][1])
 
         A = temp_pool.get_quantum_operator('commuting_grp_lex')
 
         U, phase1 = trotterize(A, trotter_number=self._trotter_number)
-        Uvqc = qforte.QuantumCircuit()
-        Uvqc.add_circuit(self._Uprep)
-        Uvqc.add_circuit(U)
         if phase1 != 1.0 + 0.0j:
             raise ValueError("Encountered phase change, phase not equal to (1.0 + 0.0i)")
 
+        Uvqc = qforte.QuantumCircuit()
+        Uvqc.add_circuit(self._Uprep)
+        Uvqc.add_circuit(U)
+
         return Uvqc
-
-    # def measure_gradient2(self, params=None):
-    #     """
-    #     Parameters
-    #     ----------
-    #     HAm : QuantumOpPool
-    #         The commutator to measure.
-    #
-    #     Ucirc : QuantumCircuit
-    #         The state preparation circuit.
-    #     """
-    #
-    #     if self._fast==False:
-    #         raise ValueError("self._fast must be True for gradient measurement.")
-    #
-    #     grads = []
-    #     M = len(self._tamps)
-    #     omega_o = ref_to_basis_idx(self._ref)
-    #
-    #     for mu in range(M):
-    #         lo_pool = qf.SQOpPool()
-    #         hi_pool = qf.SQOpPool()
-    #         if params is None:
-    #             for nu in range(mu):
-    #                 # nu indexes term THAT ARE ALREDY INCLUDED from the pool
-    #                 tamp = self._tamps[nu] # actual amp t_nu
-    #                 top = self._tops[nu] # actual pool idx for K_nu
-    #                 lo_pool.add_term(tamp, self._pool[top][1])
-    #
-    #             for nu in range(mu, M):
-    #                 tamp = self._tamps[nu]
-    #                 top = self._tops[nu]
-    #                 hi_pool.add_term(tamp, self._pool[top][1])
-    #
-    #
-    #         else:
-    #             for nu in range(mu):
-    #                 tamp = params[nu]
-    #                 top = self._tops[nu]
-    #                 lo_pool.add_term(tamp, self._pool[top][1])
-    #
-    #             for nu in range(mu, M):
-    #                 tamp = params[nu]
-    #                 top = self._tops[nu]
-    #                 hi_pool.add_term(tamp, self._pool[top][1])
-    #
-    #         Kmu = self._pool[self._tops[mu]][1].jw_transform()
-    #         Kmu.mult_coeffs(self._pool[self._tops[mu]][0])
-    #
-    #         Alo = lo_pool.get_quantum_operator('commuting_grp_lex')
-    #         Ahi = hi_pool.get_quantum_operator('commuting_grp_lex')
-    #
-    #         Ulo, plo = trotterize(Alo, trotter_number=self._trotter_number)
-    #         Uhi, phi = trotterize(Ahi, trotter_number=self._trotter_number)
-    #         if (plo != 1.0 + 0.0j) or (phi != 1.0 + 0.0j):
-    #             raise ValueError("Encountered phase change, phase not equal to (1.0 + 0.0i)")
-    #
-    #         qc = qforte.QuantumComputer(self._nqb)
-    #         qc.apply_circuit(self._Uprep)
-    #         qc.apply_circuit(Ulo)
-    #         qc.apply_operator(Kmu)
-    #         qc.apply_circuit(Uhi)
-    #         qc.apply_operator(self._qb_ham)
-    #         qc.apply_circuit(Uhi.adjoint())
-    #         qc.apply_circuit(Ulo.adjoint())
-    #
-    #         grads.append( 2.0*qc.get_coeff_vec()[omega_o] )
-    #
-    #
-    #     for val in grads:
-    #         assert(np.isclose(np.imag(val), 0.0))
-    #
-    #     # self._curr_grad_norm = np.linalg.norm(grads)
-    #
-    #     return np.real(grads)
-
-    def measure_gradient(self, params=None, use_entire_pool=False):
-        """
-        Parameters
-        ----------
-        HAm : QuantumOpPool
-            The commutator to measure.
-
-        Ucirc : QuantumCircuit
-            The state preparation circuit.
-        """
-
-        if self._fast==False:
-            raise ValueError("self._fast must be True for gradient measurement.")
-
-        grads = np.zeros(len(self._tamps))
-        M = len(self._tamps)
-
-        if use_entire_pool:
-            M = len(self._pool)
-            pool_amps = np.zeros(M)
-            for tamp, top in zip(self._tamps, self._tops):
-                pool_amps[top] = tamp
-        else:
-            M = len(self._tamps)
-
-        grads = np.zeros(M)
-
-        if params is None:
-            Utot = self.build_Uvqc()
-        else:
-            Utot = self.build_Uvqc(params)
-
-        qc_psi = qforte.QuantumComputer(self._nqb) # build | sig_N > according ADAPT-VQE analytial grad section
-        qc_psi.apply_circuit(Utot)
-        qc_sig = qforte.QuantumComputer(self._nqb) # build | psi_N > according ADAPT-VQE analytial grad section
-        psi_i = copy.deepcopy(qc_psi.get_coeff_vec())
-        qc_sig.set_coeff_vec(copy.deepcopy(psi_i)) # not sure if copy is faster or reapplication of state
-        qc_sig.apply_operator(self._qb_ham)
-
-        mu = M-1
-
-        # find <sing_N | K_N | psi_N>
-        if use_entire_pool:
-            Kmu_prev = self._pool[mu][1].jw_transform()
-            Kmu_prev.mult_coeffs(self._pool[mu][0])
-        else:
-            Kmu_prev = self._pool[self._tops[mu]][1].jw_transform()
-            Kmu_prev.mult_coeffs(self._pool[self._tops[mu]][0])
-
-        qc_psi.apply_operator(Kmu_prev)
-        grads[mu] = 2.0 * np.real(np.vdot(qc_sig.get_coeff_vec(), qc_psi.get_coeff_vec()))
-
-        #reset Kmu_prev |psi_i> -> |psi_i>
-        qc_psi.set_coeff_vec(copy.deepcopy(psi_i))
-
-        for mu in reversed(range(M-1)):
-
-            # mu => N-1 => M-2
-            # mu+1 => N => M-1
-            # Kmu => KN-1
-            # Kmu_prev => KN
-
-            if use_entire_pool:
-                tamp = pool_amps[mu+1]
-            elif params is None:
-                tamp = self._tamps[mu+1]
-            else:
-                tamp = params[mu+1]
-
-            if use_entire_pool:
-                Kmu = self._pool[mu][1].jw_transform()
-                Kmu.mult_coeffs(self._pool[mu][0])
-            else:
-                Kmu = self._pool[self._tops[mu]][1].jw_transform()
-                Kmu.mult_coeffs(self._pool[self._tops[mu]][0])
-
-            Umu, pmu = trotterize(Kmu_prev, factor=-tamp, trotter_number=self._trotter_number)
-
-            if (pmu != 1.0 + 0.0j):
-                raise ValueError("Encountered phase change, phase not equal to (1.0 + 0.0i)")
-
-            qc_sig.apply_circuit(Umu)
-            qc_psi.apply_circuit(Umu)
-            psi_i = copy.deepcopy(qc_psi.get_coeff_vec())
-
-            qc_psi.apply_operator(Kmu)
-            grads[mu] = 2.0 * np.real(np.vdot(qc_sig.get_coeff_vec(), qc_psi.get_coeff_vec()))
-
-            #reset Kmu |psi_i> -> |psi_i>
-            qc_psi.set_coeff_vec(copy.deepcopy(psi_i))
-            Kmu_prev = Kmu
-
-        # self._curr_grad_norm = np.linalg.norm(grads)
-
-        for val in grads:
-            assert(np.isclose(np.imag(val), 0.0))
-
-        return grads
 
     def measure_energy(self, Ucirc):
         """
@@ -261,64 +82,13 @@ class UCCPQE(PQE):
         return val
 
     def energy_feval(self, params):
-        Ucirc = self.build_Uvqc(params=params)
-        # self._prev_energy = self._curr_energy
+        Ucirc = self.build_Uvqc(amplitudes=params)
         Energy = self.measure_energy(Ucirc)
-
-        # if(self._noise_factor > 1e-12):
-        #     Energy = np.random.normal(Energy, self._noise_factor)
 
         self._curr_energy = Energy
         return Energy
 
-    def gradient_ary_feval(self, params):
-        grads = self.measure_gradient(params)
-
-        if(self._noise_factor > 1e-14):
-            noisy_grads = []
-            for grad_m in grads:
-                noisy_grads.append(np.random.normal(np.real(grad_m), self._noise_factor))
-            grads = noisy_grads
-
-        self._curr_grad_norm = np.linalg.norm(grads)
-        self._grad_vec_evals += 1
-        self._grad_m_evals += len(self._tamps)
-
-        # iter_str = str(int(self._grad_vec_evals))
-        # np.savetxt(f"qf_gsd_grad_{iter_str}.dat", np.real(grads))
-        # np.savetxt(f"qf_gsd_params_{iter_str}.dat", np.real(params))
-
-        return np.asarray(grads)
-
-    # def callback(self, x):
-    #     # print(f"\n -Minimum energy this iteration:    {self.energy_feval(x):+12.10f}")
-    #
-    #     self._k_counter += 1
-    #
-    #     if(self._k_counter == 1):
-    #         # print(f'     {self._k_counter:7}        {self._curr_energy:+12.10f}       -----------      {self._grad_vec_evals:4}         {self._curr_grad_norm:+12.10f}')
-    #         print('\n    k iteration         Energy               dE           Ngvec ev      Ngm ev*         ||g||')
-    #         print('--------------------------------------------------------------------------------------------------')
-    #         if (self._print_summary_file):
-    #             f = open("summary.dat", "w+", buffering=1)
-    #             f.write('\n#    k iteration         Energy               dE           Ngvec ev      Ngm ev*         ||g||')
-    #             f.write('\n#--------------------------------------------------------------------------------------------------')
-    #             f.close()
-    #
-    #     # else:
-    #     dE = self._curr_energy - self._prev_energy
-    #     print(f'     {self._k_counter:7}        {self._curr_energy:+12.10f}      {dE:+12.10f}      {self._grad_vec_evals:4}        {self._grad_m_evals:6}       {self._curr_grad_norm:+12.10f}')
-    #
-    #     if (self._print_summary_file):
-    #         f = open("summary.dat", "a", buffering=1)
-    #         f.write(f'\n       {self._k_counter:7}        {self._curr_energy:+12.12f}      {dE:+12.12f}      {self._grad_vec_evals:4}        {self._grad_m_evals:6}       {self._curr_grad_norm:+12.12f}')
-    #         f.close()
-    #
-    #     self._prev_energy = self._curr_energy
-
     def verify_required_UCCPQE_attributes(self):
-        # if self._use_analytic_grad is None:
-        #     raise NotImplementedError('Concrete UCCVQE class must define self._use_analytic_grad attribute.')
 
         if not hasattr(self, '_pool_type'):
             raise NotImplementedError('Concrete UCCVQE class must define self._pool_type attribute.')

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -11,7 +11,7 @@ from qforte.utils.trotterization import trotterize
 
 import numpy as np
 
-class UCCPQE(PQE):
+class UCCPQE(PQE, UCC):
 
     def fill_pool(self):
 
@@ -34,27 +34,6 @@ class UCCPQE(PQE):
         self._curr_grad_norm = 0.0
 
         self._Nm = [len(operator.jw_transform().terms()) for _, operator in self._pool_obj.terms()]
-
-    # TODO (opt major): write a C function that prepares this super efficiently
-    def build_Uvqc(self, amplitudes=None):
-        """ This function returns the QuantumCircuit object built
-        from the appropiate amplitudes (tops)
-
-        Parameters
-        ----------
-        amplitudes : list
-            A list of parameters that define the variational degrees of freedom in
-            the state preparation circuit Uvqc. This is needed for the scipy minimizer.
-        """
-
-        ansatz = UCC(self._trotter_number, self._tamps, self._tops, self._pool)
-        U = ansatz.ansatz_circuit(amplitudes)
-
-        Uvqc = qforte.QuantumCircuit()
-        Uvqc.add_circuit(self._Uprep)
-        Uvqc.add_circuit(U)
-
-        return Uvqc
 
     def verify_required_UCCPQE_attributes(self):
 

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -56,25 +56,6 @@ class UCCPQE(PQE):
 
         return Uvqc
 
-    def measure_energy(self, Ucirc):
-        """
-        Parameters
-        ----------
-        Ucirc : QuantumCircuit
-            The state preparation circuit.
-        """
-        if self._fast:
-            myQC = qforte.QuantumComputer(self._nqb)
-            myQC.apply_circuit(Ucirc)
-            val = np.real(myQC.direct_op_exp_val(self._qb_ham))
-        else:
-            Exp = qforte.Experiment(self._nqb, Ucirc, self._qb_ham, 2000)
-            empty_params = []
-            val = Exp.perfect_experimental_avg(empty_params)
-
-        assert(np.isclose(np.imag(val),0.0))
-        return val
-
     def verify_required_UCCPQE_attributes(self):
 
         if not hasattr(self, '_pool_type'):

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -13,28 +13,6 @@ import numpy as np
 
 class UCCPQE(PQE, UCC):
 
-    def fill_pool(self):
-
-        self._pool_obj = qf.SQOpPool()
-        self._pool_obj.set_orb_spaces(self._ref)
-
-        if self._pool_type in {'sa_SD', 'GSD', 'SD', 'SDT', 'SDTQ', 'SDTQP', 'SDTQPH'}:
-            self._pool_obj.fill_pool(self._pool_type)
-        else:
-            raise ValueError('Invalid operator pool type specified.')
-
-        self._pool = self._pool_obj.terms()
-
-        self._grad_vec_evals = 0
-        self._grad_m_evals = 0
-        self._k_counter = 0
-        self._grad_m_evals = 0
-        self._prev_energy = self._hf_energy
-        self._curr_energy = 0.0
-        self._curr_grad_norm = 0.0
-
-        self._Nm = [len(operator.jw_transform().terms()) for _, operator in self._pool_obj.terms()]
-
     def verify_required_UCCPQE_attributes(self):
 
         if not hasattr(self, '_pool_type'):

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -11,7 +11,7 @@ from qforte.utils.trotterization import trotterize
 
 import numpy as np
 
-class UCCVQE(VQE):
+class UCCVQE(VQE, UCC):
 
     @abstractmethod
     def get_num_ham_measurements(self):
@@ -50,27 +50,6 @@ class UCCVQE(VQE):
         self._commutator_pool = self._pool_obj.get_quantum_op_pool()
         self._commutator_pool.join_as_commutator(self._qb_ham)
         print('==> Commutator pool construction complete.')
-
-    # TODO (opt major): write a C function that prepares this super efficiently
-    def build_Uvqc(self, amplitudes=None):
-        """ This function returns the QuantumCircuit object built
-        from the appropriate amplitudes (tops)
-
-        Parameters
-        ----------
-        amplitudes : list
-            A list of parameters that define the variational degrees of freedom in
-            the state preparation circuit Uvqc. This is needed for the scipy minimizer.
-        """
-
-        ansatz = UCC(self._trotter_number, self._tamps, self._tops, self._pool)
-        U = ansatz.ansatz_circuit(amplitudes)
-
-        Uvqc = qforte.QuantumCircuit()
-        Uvqc.add_circuit(self._Uprep)
-        Uvqc.add_circuit(U)
-
-        return Uvqc
 
     def measure_operators(self, operators, Ucirc, idxs=[]):
         """

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -233,26 +233,6 @@ class UCCVQE(VQE):
 
         return grads
 
-
-    def measure_energy(self, Ucirc):
-        """
-        Parameters
-        ----------
-        Ucirc : QuantumCircuit
-            The state preparation circuit.
-        """
-        if self._fast:
-            myQC = qforte.QuantumComputer(self._nqb)
-            myQC.apply_circuit(Ucirc)
-            val = np.real(myQC.direct_op_exp_val(self._qb_ham))
-        else:
-            Exp = qforte.Experiment(self._nqb, Ucirc, self._qb_ham, 2000)
-            empty_params = []
-            val = Exp.perfect_experimental_avg(empty_params)
-
-        assert(np.isclose(np.imag(val),0.0))
-        return val
-
     def gradient_ary_feval(self, params):
         grads = self.measure_gradient(params)
 

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -21,30 +21,6 @@ class UCCVQE(VQE, UCC):
     def get_num_commut_measurements(self):
         pass
 
-    def fill_pool(self):
-        self._pool_obj = qf.SQOpPool()
-        self._pool_obj.set_orb_spaces(self._ref)
-
-        if self._pool_type in {'sa_SD', 'GSD', 'SD', 'SDT', 'SDTQ', 'SDTQP', 'SDTQPH'}:
-            self._pool_obj.fill_pool(self._pool_type)
-        else:
-            raise ValueError('Invalid operator pool type specified.')
-
-        # TODO: Having both a _pool and a _pool_obj seems redundant.
-        # Can we define magic methods so that we can just work with
-        # the pool objects, without an alias for self._pool being needed?
-        self._pool = self._pool_obj.terms()
-
-        self._grad_vec_evals = 0
-        self._grad_m_evals = 0
-        self._k_counter = 0
-        self._grad_m_evals = 0
-        self._prev_energy = self._hf_energy
-        self._curr_energy = 0.0
-        self._curr_grad_norm = 0.0
-
-        self._Nm = [len(operator.jw_transform().terms()) for _, operator in self._pool_obj.terms()]
-
     def fill_commutator_pool(self):
         print('\n\n==> Building commutator pool for gradient measurement.')
         self._commutator_pool = self._pool_obj.get_quantum_op_pool()
@@ -216,10 +192,7 @@ class UCCVQE(VQE, UCC):
         grads = self.measure_gradient(params)
 
         if(self._noise_factor > 1e-14):
-            noisy_grads = []
-            for grad_m in grads:
-                noisy_grads.append(np.random.normal(np.real(grad_m), self._noise_factor))
-            grads = noisy_grads
+            grads = [np.random.normal(np.real(grad_m), self._noise_factor) for grad_m in grads]
 
         self._curr_grad_norm = np.linalg.norm(grads)
         self._grad_vec_evals += 1

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -280,14 +280,9 @@ class UCCVQE(VQE):
         self._grad_vec_evals += 1
         self._grad_m_evals += len(self._tamps)
 
-        # iter_str = str(int(self._grad_vec_evals))
-        # np.savetxt(f"qf_gsd_grad_{iter_str}.dat", np.real(grads))
-        # np.savetxt(f"qf_gsd_params_{iter_str}.dat", np.real(params))
-
         return np.asarray(grads)
 
     def report_iteration(self, x):
-        # print(f"\n -Minimum energy this iteration:    {self.energy_feval(x):+12.10f}")
 
         self._k_counter += 1
 

--- a/src/qforte/abc/vqeabc.py
+++ b/src/qforte/abc/vqeabc.py
@@ -1,22 +1,10 @@
 from abc import abstractmethod
-from qforte.abc.algorithm import Algorithm
+from qforte.abc.algorithm import AnsatzAlgorithm
 
-class VQE(Algorithm):
-
-    @abstractmethod
-    def build_Uvqc(self):
-        pass
+class VQE(AnsatzAlgorithm):
 
     @abstractmethod
     def measure_gradient(self):
-        pass
-
-    @abstractmethod
-    def measure_energy(self):
-        pass
-
-    @abstractmethod
-    def energy_feval(self):
         pass
 
     @abstractmethod

--- a/src/qforte/quantum_computer.cc
+++ b/src/qforte/quantum_computer.cc
@@ -746,26 +746,11 @@ std::vector<std::complex<double>> QuantumComputer::direct_oppl_exp_val(
     const QuantumOpPool& qopl) {
 
     std::vector<std::complex<double>> results;
-    if(parallelism_enabled){
-        for (const auto& pl_term : qopl.terms()){
-            std::complex<double> val = direct_op_exp_val(pl_term.second);
-            results.push_back(val*pl_term.first);
-        }
-    } else {
-        std::vector<std::complex<double>> old_coeff = coeff_;
-        for (const auto& pl_term : qopl.terms()){
-            apply_operator(pl_term.second);
-            std::complex<double> val = std::inner_product(old_coeff.begin(),
-                                                          old_coeff.end(),
-                                                          coeff_.begin(),
-                                                          std::complex<double>(0.0, 0.0),
-                                                          add_c<double>,
-                                                          complex_prod<double>);
 
-            results.push_back(val*pl_term.first);
-            coeff_ = old_coeff;
-        }
+    for (const auto& pl_term : qopl.terms()) {
+        results.push_back(direct_op_exp_val(pl_term.second) * pl_term.first);
     }
+
     return results;
 }
 

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -217,6 +217,14 @@ class ADAPTVQE(UCCVQE):
         self._n_pauli_trm_measures = 0
         self._n_pauli_trm_measures_lst = []
 
+        self._grad_vec_evals = 0
+        self._grad_m_evals = 0
+        self._k_counter = 0
+        self._grad_m_evals = 0
+
+        self._curr_grad_norm = 0.0
+        self._prev_energy = self._hf_energy
+
         # Print options banner (should done for all algorithms).
         self.print_options_banner()
 

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -397,7 +397,7 @@ class ADAPTVQE(UCCVQE):
 
         else:
             print('  \n--> Begin opt with grad estimated using first-differences:')
-            print(f" Initail guess energy:              {init_gues_energy:+12.10f}")
+            print(f" Initial guess energy:              {init_gues_energy:+12.10f}")
             res =  minimize(self.energy_feval, x0,
                                     method=self._optimizer,
                                     options=opts,

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -53,7 +53,6 @@ class SPQE(UCCPQE):
         self._res_vec_evals = 0
         self._res_m_evals = 0
 
-        self._prev_energy = 0.0
         self._curr_energy = 0.0
 
         self._n_classical_params = 0

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -377,11 +377,3 @@ class UCCNPQE(UCCPQE):
             self._tops.append(l)
             self._tamps.append(0.0)
 
-        # TODO: make this a useable option
-        # if self._use_mp2_guess_amps:
-        #     self._tamps = self.get_mp2_guess_amps()
-
-    ### totally junk experimental functions
-    def get_mp2_guess_amps(self):
-        # TODO: implement, look into generalizd diagonal preconditioners.
-        pass

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -94,18 +94,6 @@ class UCCNVQE(UCCVQE):
         An SDOpPool object corresponding to the specified operators of
         interest.
 
-    _pool : list of tuple(complex, SqOperator)
-        The linear combination of (optionally symmetrized) single and double
-        excitation operators to consider. This is represented as a list.
-        Each entry is a pair of a complex coefficient and an SqOperator object.
-
-    _tops : list
-        A list of indices representing selected operators in the pool.
-
-    _tamps : list
-        A list of amplitudes (to be optimized) representing selected
-        operators in the pool.
-
     _commutator_pool : list
         The QuantumOperator objects representing the commutators [H, Am] of the
         Hamiltonian (H) and each member of the operator pool (Am).

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -2,7 +2,7 @@
 uccsdvqe.py
 ====================================
 A class for using an experiment to execute the variational quantum eigensolver
-for a trotterized UCCN anxatz.
+for a trotterized UCCN ansatz.
 """
 
 import qforte
@@ -201,6 +201,13 @@ class UCCNVQE(UCCVQE):
         self._n_classical_params = 0
         self._n_cnot = 0
         self._n_pauli_trm_measures = 0
+        self._grad_vec_evals = 0
+        self._grad_m_evals = 0
+        self._k_counter = 0
+        self._grad_m_evals = 0
+
+        self._curr_grad_norm = 0.0
+        self._prev_energy = self._hf_energy
 
         # Print options banner (should done for all algorithms).
         self.print_options_banner()


### PR DESCRIPTION
This cleans up anything and everything involving UCC to eliminate code duplication. We now have an `algorithm` subclass called `AnsatzAlgorithm` for any algorithm that requires an ansatz. We have a further subclass for this, UCC, for functions further common to when that ansatz is UCC.

Hooray for -400 LoC. Tests still pass.