### PR TITLE
Rename make_gate and make input more friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ import qforte
 
 # Construct a Bell state.
 computer = qforte.QuantumComputer(2)
-computer.apply_gate(qforte.make_gate('H',0,0))
-computer.apply_gate(qforte.make_gate('cX',1,0))
+computer.apply_gate(qforte.gate('H',0))
+computer.apply_gate(qforte.gate('cX',1,0))
 
 # Run quantum phase estimation on H2.
 from qforte.qpea.qpe import QPE

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -46,7 +46,8 @@ PYBIND11_MODULE(qforte, m) {
         .def("terms", &SQOpPool::terms)
         .def("set_orb_spaces", &SQOpPool::set_orb_spaces)
         .def("get_quantum_op_pool", &SQOpPool::get_quantum_op_pool)
-        .def("get_quantum_operator", &SQOpPool::get_quantum_operator, py::arg("order_type") ,py::arg("combine_like_terms") = true)
+        .def("get_quantum_operator", &SQOpPool::get_quantum_operator, py::arg("order_type"),
+             py::arg("combine_like_terms") = true)
         .def("fill_pool", &SQOpPool::fill_pool)
         .def("str", &SQOpPool::str);
 
@@ -95,7 +96,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("apply_circuit", &QuantumComputer::apply_circuit)
         .def("apply_gate_safe", &QuantumComputer::apply_gate_safe)
         .def("apply_gate", &QuantumComputer::apply_gate)
-        .def("apply_constant",  &QuantumComputer::apply_constant)
+        .def("apply_constant", &QuantumComputer::apply_constant)
         .def("measure_circuit", &QuantumComputer::measure_circuit)
         .def("measure_z_readouts_fast", &QuantumComputer::measure_z_readouts_fast)
         .def("measure_readouts", &QuantumComputer::measure_readouts)
@@ -139,6 +140,17 @@ PYBIND11_MODULE(qforte, m) {
         .def("reset", &local_timer::reset)
         .def("get", &local_timer::get);
 
-    m.def("make_gate", &make_gate, "type"_a, "target"_a, "control"_a, "parameter"_a = 0.0);
+    m.def(
+        "make_gate",
+        [](std::string type, size_t target, std::complex<double> parameter) {
+            return make_gate(type, target, target, parameter);
+        },
+        "type"_a, "target"_a, "parameter"_a = 0.0);
+    m.def(
+        "make_gate",
+        [](std::string type, size_t target, size_t control, std::complex<double> parameter) {
+            return make_gate(type, target, control, parameter);
+        },
+        "type"_a, "target"_a, "control"_a, "parameter"_a = 0.0);
     m.def("make_control_gate", &make_control_gate, "control"_a, "QuantumGate"_a);
 }

--- a/src/qforte/helper/advance_gates_helper.py
+++ b/src/qforte/helper/advance_gates_helper.py
@@ -20,13 +20,13 @@ def Toffoli(i,j,k):
     :param k: target qubit
     """
 
-    T1 = qforte.make_gate('T', i, i)
-    T2 = qforte.make_gate('T', j, j)
-    T3 = qforte.make_gate('T', k, k)
-    C12 = qforte.make_gate('cX', j, i)
-    C13 = qforte.make_gate('cX', k, i)
-    C23 = qforte.make_gate('cX', k, j)
-    H3 = qforte.make_gate('H', k, k)
+    T1 = qforte.gate('T', i, i)
+    T2 = qforte.gate('T', j, j)
+    T3 = qforte.gate('T', k, k)
+    C12 = qforte.gate('cX', j, i)
+    C13 = qforte.gate('cX', k, i)
+    C23 = qforte.gate('cX', k, j)
+    H3 = qforte.gate('H', k, k)
 
     T_circ = qforte.QuantumCircuit()
     T_circ.add_gate(H3)
@@ -58,10 +58,10 @@ def Fredkin(i,j,k):
     :param k: swap qubit 2
     """
 
-    C12 = qforte.make_gate('cX', j, i)
-    C32 = qforte.make_gate('cX', j, k)
-    CV23 = qforte.make_gate('cV', k, j)
-    CV13 = qforte.make_gate('cV', k, i)
+    C12 = qforte.gate('cX', j, i)
+    C32 = qforte.gate('cX', j, k)
+    CV23 = qforte.gate('cV', k, j)
+    CV13 = qforte.gate('cV', k, i)
 
     F_circ = qforte.QuantumCircuit()
     F_circ.add_gate(C32)

--- a/src/qforte/helper/io_helper.py
+++ b/src/qforte/helper/io_helper.py
@@ -83,12 +83,12 @@ def build_circuit(Inputstr):
     for i in range(len(sepstr)):
         inputgate = sepstr[i].split('_')
         if len(inputgate) == 2:
-            circ.add_gate(qforte.make_gate(inputgate[0], int(inputgate[1]), int(inputgate[1])))
+            circ.add_gate(qforte.gate(inputgate[0], int(inputgate[1]), int(inputgate[1])))
         else:
             if 'R' in inputgate[0]:
-                circ.add_gate(qforte.make_gate(inputgate[0], int(inputgate[1]), int(inputgate[1]), float(inputgate[2])))
+                circ.add_gate(qforte.gate(inputgate[0], int(inputgate[1]), int(inputgate[1]), float(inputgate[2])))
             else:
-                circ.add_gate(qforte.make_gate(inputgate[0], int(inputgate[1]), int(inputgate[2])))
+                circ.add_gate(qforte.gate(inputgate[0], int(inputgate[1]), int(inputgate[2])))
 
     return circ
 

--- a/src/qforte/helper/operator_helper.py
+++ b/src/qforte/helper/operator_helper.py
@@ -25,7 +25,7 @@ def build_from_openfermion(OF_qubitops, time_evo_factor = 1.0):
             action_string = OF_qubitops.action_strings[OF_qubitops.actions.index(action)]
 
             #Make qforte gates and add to circuit
-            gate_this = qforte.make_gate(action_string, index, index)
+            gate_this = qforte.gate(action_string, index, index)
             circ_term.add_gate(gate_this)
 
         #Add this term to operator

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -163,7 +163,7 @@ class QITE(Algorithm):
                 nygates = 0
                 temp_rho = qf.QuantumCircuit()
                 for gate in rho.gates():
-                    temp_rho.add_gate(qf.make_gate(gate.gate_id(), gate.target(), gate.control()))
+                    temp_rho.add_gate(qf.gate(gate.gate_id(), gate.target(), gate.control()))
                     if (gate.gate_id() == "Y"):
                         nygates += 1
 

--- a/src/qforte/qkd/mrsqk.py
+++ b/src/qforte/qkd/mrsqk.py
@@ -302,7 +302,7 @@ class MRSQK(QSD):
                 Um = qforte.QuantumCircuit()
                 for j in range(self._nqb):
                     if ref[j] == 1:
-                        Um.add_gate(qforte.make_gate('X', j, j))
+                        Um.add_gate(qforte.gate('X', j, j))
                         phase1 = 1.0
 
                 if(m>0):
@@ -368,7 +368,7 @@ class MRSQK(QSD):
             Un = qforte.QuantumCircuit()
             for j in range(self._nqb):
                 if ref[j] == 1:
-                    Un.add_gate(qforte.make_gate('X', j, j))
+                    Un.add_gate(qforte.gate('X', j, j))
 
             QC = qforte.QuantumComputer(self._nqb)
             QC.apply_circuit(Un)

--- a/src/qforte/qkd/srqk.py
+++ b/src/qforte/qkd/srqk.py
@@ -341,23 +341,23 @@ class SRQK(QSD):
             cir = qforte.QuantumCircuit()
             for j in range(self._nqb):
                 if self._ref[j] == 1:
-                    cir.add_gate(qforte.make_gate('X', j, j))
+                    cir.add_gate(qforte.gate('X', j, j))
 
-            cir.add_gate(qforte.make_gate('H', ancilla_idx, ancilla_idx))
+            cir.add_gate(qforte.gate('H', ancilla_idx, ancilla_idx))
 
             cir.add_circuit(Uk)
 
-            cir.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+            cir.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
             cir.add_circuit(Ub)
-            cir.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+            cir.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
 
             X_op = qforte.QuantumOperator()
             x_circ = qforte.QuantumCircuit()
             Y_op = qforte.QuantumOperator()
             y_circ = qforte.QuantumCircuit()
 
-            x_circ.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
-            y_circ.add_gate(qforte.make_gate('Y', ancilla_idx, ancilla_idx))
+            x_circ.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
+            y_circ.add_gate(qforte.gate('Y', ancilla_idx, ancilla_idx))
 
             X_op.add_term(1.0, x_circ)
             Y_op.add_term(1.0, y_circ)
@@ -383,30 +383,30 @@ class SRQK(QSD):
                     gate_str = gate.gate_id()
                     target = gate.target()
                     control_gate_str = 'c' + gate_str
-                    cV_l.add_gate(qforte.make_gate(control_gate_str, target, ancilla_idx))
+                    cV_l.add_gate(qforte.gate(control_gate_str, target, ancilla_idx))
 
                 cir = qforte.QuantumCircuit()
                 # TODO (opt): use Uprep
                 for j in range(self._nqb):
                     if self._ref[j] == 1:
-                        cir.add_gate(qforte.make_gate('X', j, j))
+                        cir.add_gate(qforte.gate('X', j, j))
 
-                cir.add_gate(qforte.make_gate('H', ancilla_idx, ancilla_idx))
+                cir.add_gate(qforte.gate('H', ancilla_idx, ancilla_idx))
 
                 cir.add_circuit(Uk)
                 cir.add_circuit(cV_l)
 
-                cir.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+                cir.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
                 cir.add_circuit(Ub)
-                cir.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+                cir.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
 
                 X_op = qforte.QuantumOperator()
                 x_circ = qforte.QuantumCircuit()
                 Y_op = qforte.QuantumOperator()
                 y_circ = qforte.QuantumCircuit()
 
-                x_circ.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
-                y_circ.add_gate(qforte.make_gate('Y', ancilla_idx, ancilla_idx))
+                x_circ.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
+                y_circ.add_gate(qforte.gate('Y', ancilla_idx, ancilla_idx))
 
                 X_op.add_term(1.0, x_circ)
                 Y_op.add_term(1.0, y_circ)

--- a/src/qforte/qpea/qpe.py
+++ b/src/qforte/qpea/qpe.py
@@ -185,7 +185,7 @@ class QPE(Algorithm):
         """
         Uhad = qforte.QuantumCircuit()
         for j in range(self._abegin, self._aend + 1):
-            Uhad.add_gate(qforte.make_gate('H', j, j))
+            Uhad.add_gate(qforte.gate('H', j, j))
 
         return Uhad
 
@@ -241,7 +241,7 @@ class QPE(Algorithm):
                                                trotter_number=self._trotter_number)
 
             # Rotation for the scaler Hamiltonian term
-            Udyn.add_gate(qforte.make_gate('R', ancilla_idx, ancilla_idx,  -1.0 * np.sum(scaler_terms) * float(tn)))
+            Udyn.add_gate(qforte.gate('R', ancilla_idx, ancilla_idx,  -1.0 * np.sum(scaler_terms) * float(tn)))
 
             # NOTE: Approach uses 2^ancilla_idx blocks of the time evolution circuit
             for i in range(tn):
@@ -279,10 +279,10 @@ class QPE(Algorithm):
         qft_circ = qforte.QuantumCircuit()
         lens = self._aend - self._abegin + 1
         for j in range(lens):
-            qft_circ.add_gate(qforte.make_gate('H', j+self._abegin, j+self._abegin))
+            qft_circ.add_gate(qforte.gate('H', j+self._abegin, j+self._abegin))
             for k in range(2, lens+1-j):
                 phase = 2.0*np.pi/(2**k)
-                qft_circ.add_gate(qforte.make_gate('cR', j+self._abegin, j+k-1+self._abegin, phase))
+                qft_circ.add_gate(qforte.gate('cR', j+self._abegin, j+k-1+self._abegin, phase))
 
         if direct == 'forward':
             return qft_circ
@@ -314,6 +314,6 @@ class QPE(Algorithm):
 
         Z_circ = qforte.QuantumCircuit()
         for j in range(self._abegin, self._aend + 1):
-            Z_circ.add_gate(qforte.make_gate('Z', j, j))
+            Z_circ.add_gate(qforte.gate('Z', j, j))
 
         return Z_circ

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -385,7 +385,7 @@ class SPQE(UCCPQE):
         for i in range(self._nqb):
             qc = qforte.QuantumComputer(self._nqb)
             qc.apply_circuit(build_Uprep(self._ref, 'reference'))
-            qc.apply_gate(qforte.make_gate('X', i, i))
+            qc.apply_gate(qforte.gate('X', i, i))
             Ei = qc.direct_op_exp_val(self._qb_ham)
 
             if(i<sum(self._ref)):

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -361,7 +361,7 @@ class UCCNPQE(UCCPQE):
         for i in range(self._nqb):
             qc = qforte.QuantumComputer(self._nqb)
             qc.apply_circuit(build_Uprep(self._ref, 'reference'))
-            qc.apply_gate(qforte.make_gate('X', i, i))
+            qc.apply_gate(qforte.gate('X', i, i))
             Ei = qc.direct_op_exp_val(self._qb_ham)
 
             if(i<sum(self._ref)):

--- a/src/qforte/utils/exponentiate.py
+++ b/src/qforte/utils/exponentiate.py
@@ -41,16 +41,16 @@ def exponentiate_single_term(coefficient, term, Use_cRz=False, ancilla_idx=None,
         control = gate.control()
 
         if (id == 'X'):
-            to_z.add_gate(qforte.make_gate('H', target, control))
-            to_original.add_gate(qforte.make_gate('H', target, control))
+            to_z.add_gate(qforte.gate('H', target, control))
+            to_original.add_gate(qforte.gate('H', target, control))
         elif (id == 'Y'):
-            to_z.add_gate(qforte.make_gate('Rzy', target, control))
-            to_original.add_gate(qforte.make_gate('Rzy', target, control))
+            to_z.add_gate(qforte.gate('Rzy', target, control))
+            to_original.add_gate(qforte.gate('Rzy', target, control))
         elif (id == 'I'):
             continue
 
         if (prev_target is not None):
-            cX_circ.add_gate(qforte.make_gate('cX', target, prev_target))
+            cX_circ.add_gate(qforte.gate('cX', target, prev_target))
 
         prev_target = target
         max_target = target
@@ -59,21 +59,21 @@ def exponentiate_single_term(coefficient, term, Use_cRz=False, ancilla_idx=None,
     # TODO(Nick): investigate real/imaginary usage of 'factor' in below expression
 
     if(Use_cRz):
-        z_rot = qforte.make_gate('cRz', max_target, ancilla_idx, -2.0 * np.imag(coefficient))
+        z_rot = qforte.gate('cRz', max_target, ancilla_idx, -2.0 * np.imag(coefficient))
     else:
-        z_rot = qforte.make_gate('Rz', max_target, max_target, -2.0 * np.imag(coefficient))
+        z_rot = qforte.gate('Rz', max_target, max_target, -2.0 * np.imag(coefficient))
 
     # Assemble the actual exponential
     exponential.add_circuit(to_z)
     exponential.add_circuit(cX_circ)
 
     if(Use_open_cRz):
-        exponential.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+        exponential.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
 
     exponential.add_gate(z_rot)
 
     if(Use_open_cRz):
-        exponential.add_gate(qforte.make_gate('X', ancilla_idx, ancilla_idx))
+        exponential.add_gate(qforte.gate('X', ancilla_idx, ancilla_idx))
 
     adj_cX_circ = cX_circ.adjoint()
     exponential.add_circuit(adj_cX_circ)

--- a/src/qforte/utils/qft.py
+++ b/src/qforte/utils/qft.py
@@ -19,18 +19,18 @@ def qft_circuit(na, nb, direct):
     qft_circ = qforte.QuantumCircuit()
     lens = nb - na + 1
     for j in range(lens):
-        qft_circ.add_gate(qforte.make_gate('H', j+na, j+na))
+        qft_circ.add_gate(qforte.gate('H', j+na, j+na))
         for k in range(2, lens+1-j):
             phase = 2.0*numpy.pi/(2**k)
-            qft_circ.add_gate(qforte.make_gate('cR', j+na, j+k-1+na, phase))
+            qft_circ.add_gate(qforte.gate('cR', j+na, j+k-1+na, phase))
 
     # Build reversing circuit
     if lens % 2 == 0:
         for i in range(int(lens/2)):
-            qft_circ.add_gate(qforte.make_gate('SWAP', i+na, lens-1-i+na))
+            qft_circ.add_gate(qforte.gate('SWAP', i+na, lens-1-i+na))
     else:
         for i in range(int((lens-1)/2)):
-            qft_circ.add_gate(qforte.make_gate('SWAP', i+na, lens-1-i+na))
+            qft_circ.add_gate(qforte.gate('SWAP', i+na, lens-1-i+na))
 
     if direct == 'forward':
         return qft_circ

--- a/src/qforte/utils/state_prep.py
+++ b/src/qforte/utils/state_prep.py
@@ -6,7 +6,7 @@ def build_Uprep(ref, trial_state_type):
     if trial_state_type == 'reference':
         for j in range(len(ref)):
             if ref[j] == 1:
-                Uprep.add_gate(qforte.make_gate('X', j, j))
+                Uprep.add_gate(qforte.gate('X', j, j))
     else:
         raise ValueError("Only 'reference' supported as state preparation type")
 

--- a/src/qforte/utils/transforms.py
+++ b/src/qforte/utils/transforms.py
@@ -68,7 +68,7 @@ def organizer_to_circuit(op_organizer):
     for coeff, word in op_organizer:
         circ = qforte.QuantumCircuit()
         for letter in word:
-            circ.add_gate(qforte.make_gate(letter[0], letter[1], letter[1]))
+            circ.add_gate(qforte.gate(letter[0], letter[1], letter[1]))
 
         operator.add_term(coeff, circ)
 

--- a/tests/build_operator.py
+++ b/tests/build_operator.py
@@ -9,11 +9,11 @@ class BuilderTests(unittest.TestCase):
         trial_state = qforte.QuantumComputer(4)
 
         trial_prep = [None]*5
-        trial_prep[0] = qforte.make_gate('H',0,0)
-        trial_prep[1] = qforte.make_gate('H',1,1)
-        trial_prep[2] = qforte.make_gate('H',2,2)
-        trial_prep[3] = qforte.make_gate('H',3,3)
-        trial_prep[4] = qforte.make_gate('cX',0,1)
+        trial_prep[0] = qforte.gate('H',0,0)
+        trial_prep[1] = qforte.gate('H',1,1)
+        trial_prep[2] = qforte.gate('H',2,2)
+        trial_prep[3] = qforte.gate('H',3,3)
+        trial_prep[4] = qforte.gate('cX',0,1)
 
         trial_circ = qforte.QuantumCircuit()
 

--- a/tests/circuit_tests.py
+++ b/tests/circuit_tests.py
@@ -15,20 +15,20 @@ class CircuitTests(unittest.TestCase):
         circ = qforte.QuantumCircuit()
 
         for i in range(num_qubits):
-            prep_circ.add_gate(qforte.make_gate('H',i, i))
+            prep_circ.add_gate(qforte.gate('H',i, i))
 
         for i in range(num_qubits):
-            prep_circ.add_gate(qforte.make_gate('cR',i, i+1, 1.116 / (i+1.0)))
+            prep_circ.add_gate(qforte.gate('cR',i, i+1, 1.116 / (i+1.0)))
 
         for i in range(num_qubits - 1):
-            circ.add_gate(qforte.make_gate('cX',i, i+1))
-            circ.add_gate(qforte.make_gate('cX',i+1, i))
-            circ.add_gate(qforte.make_gate('cY',i, i+1))
-            circ.add_gate(qforte.make_gate('cY',i+1, i))
-            circ.add_gate(qforte.make_gate('cZ',i, i+1))
-            circ.add_gate(qforte.make_gate('cZ',i+1, i))
-            circ.add_gate(qforte.make_gate('cR',i, i+1, 3.14159 / (i+1.0)))
-            circ.add_gate(qforte.make_gate('cR',i+1, i, 2.17284 / (i+1.0)))
+            circ.add_gate(qforte.gate('cX',i, i+1))
+            circ.add_gate(qforte.gate('cX',i+1, i))
+            circ.add_gate(qforte.gate('cY',i, i+1))
+            circ.add_gate(qforte.gate('cY',i+1, i))
+            circ.add_gate(qforte.gate('cZ',i, i+1))
+            circ.add_gate(qforte.gate('cZ',i+1, i))
+            circ.add_gate(qforte.gate('cR',i, i+1, 3.14159 / (i+1.0)))
+            circ.add_gate(qforte.gate('cR',i+1, i, 2.17284 / (i+1.0)))
 
 
         qc1.apply_circuit_safe(prep_circ)

--- a/tests/comprehensive_gates_tests.py
+++ b/tests/comprehensive_gates_tests.py
@@ -8,10 +8,10 @@ prep_circ = qforte.QuantumCircuit()
 ct_lst = [(4,3), (4,2), (4,1), (4,0), (3,2), (3,1), (3,0), (2,1), (2,0), (1,0)]
 
 for i in range(num_qubits):
-    prep_circ.add_gate(qforte.make_gate('H',i, i))
+    prep_circ.add_gate(qforte.gate('H',i, i))
 
 for i in range(num_qubits):
-    prep_circ.add_gate(qforte.make_gate('cR',i, i+1, 1.116 / (i+1.0)))
+    prep_circ.add_gate(qforte.gate('cR',i, i+1, 1.116 / (i+1.0)))
 
 def test_circ_vec_builder(qb_list, id):
     circ_vec_tc = [qforte.QuantumCircuit() for i in range(len(qb_list))]
@@ -20,12 +20,12 @@ def test_circ_vec_builder(qb_list, id):
         t = pair[0]
         c = pair[1]
         if(id == 'cR'):
-            circ_vec_ct[i].add_gate(qforte.make_gate(id, t, c, 3.17*t*c))
-            circ_vec_tc[i].add_gate(qforte.make_gate(id, c, t, 1.41*t*c))
+            circ_vec_ct[i].add_gate(qforte.gate(id, t, c, 3.17*t*c))
+            circ_vec_tc[i].add_gate(qforte.gate(id, c, t, 1.41*t*c))
 
         else:
-            circ_vec_ct[i].add_gate(qforte.make_gate(id, t, c))
-            circ_vec_tc[i].add_gate(qforte.make_gate(id, c, t))
+            circ_vec_ct[i].add_gate(qforte.gate(id, t, c))
+            circ_vec_tc[i].add_gate(qforte.gate(id, c, t))
 
     return circ_vec_tc, circ_vec_ct
 

--- a/tests/experiment_test.py
+++ b/tests/experiment_test.py
@@ -46,8 +46,8 @@ class ExperimentTests(unittest.TestCase):
 
         # circuit for making HF state
         circ = qforte.QuantumCircuit()
-        circ.add_gate(qforte.make_gate('X', 0, 0))
-        circ.add_gate(qforte.make_gate('X', 1, 1))
+        circ.add_gate(qforte.gate('X', 0, 0))
+        circ.add_gate(qforte.gate('X', 1, 1))
 
         TestExperiment = qforte.Experiment(4, circ, H2_qubit_hamiltonian, 1000000)
         params2 = []
@@ -105,8 +105,8 @@ class ExperimentTests(unittest.TestCase):
 
         # circuit for making HF state
         circ = qforte.QuantumCircuit()
-        circ.add_gate(qforte.make_gate('X', 0, 0))
-        circ.add_gate(qforte.make_gate('X', 1, 1))
+        circ.add_gate(qforte.gate('X', 0, 0))
+        circ.add_gate(qforte.gate('X', 1, 1))
 
         TestExperiment = qforte.Experiment(4, circ, H2_qubit_hamiltonian, 1000000)
         params2 = []

--- a/tests/gates_test.py
+++ b/tests/gates_test.py
@@ -13,7 +13,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        X = qforte.make_gate('X',0,0);
+        X = qforte.'X',0);
         # test X|0> = |1>
         computer.apply_gate(X)
         coeff0 = computer.coeff(basis0)
@@ -35,7 +35,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        Y = qforte.make_gate('Y',0,0);
+        Y = qforte.'Y',0,0);
         # test Y|0> = i|1>
         computer.apply_gate(Y)
         coeff0 = computer.coeff(basis0)
@@ -57,7 +57,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        Z = qforte.make_gate('Z',0,0);
+        Z = qforte.'Z',0,0);
         # test Z|0> = |0>
         computer.apply_gate(Z)
         coeff0 = computer.coeff(basis0)
@@ -80,7 +80,7 @@ class GatesTests(unittest.TestCase):
         basis2 = make_basis('10') # basis2:|01>
         basis3 = make_basis('11') # basis3:|11>
         computer = qforte.QuantumComputer(nqubits)
-        CNOT = qforte.make_gate('CNOT',0,1);
+        CNOT = qforte.'CNOT',0,1);
 
         # test CNOT|00> = |00>
         computer.set_state([(basis0,1.0)])
@@ -130,6 +130,10 @@ class GatesTests(unittest.TestCase):
         self.assertAlmostEqual(coeff2, 0.0 + 0.0j)
         self.assertAlmostEqual(coeff3, 0.0 + 0.0j)
 
+        with self.assertRaises(ValueError) as context:
+            qforte.'CNOT',0,1.0)
+            self.assertTrue(')' in str(context.exception))
+
     def test_cY_gate(self):
         # test the cY gate
         nqubits = 2
@@ -138,7 +142,7 @@ class GatesTests(unittest.TestCase):
         basis2 = make_basis('10') # basis2:|01>
         basis3 = make_basis('11') # basis3:|11>
         computer = qforte.QuantumComputer(nqubits)
-        cY = qforte.make_gate('cY',0,1);
+        cY = qforte.'cY',0,1);
 
         # test cY|00> = |00>
         computer.set_state([(basis0,1.0)])
@@ -194,25 +198,25 @@ class GatesTests(unittest.TestCase):
         # test that 1 - 1 = 0
 
         # print('\n'.join(qc.str()))
-        X = qforte.make_gate('X',0,0);
+        X = qforte.'X',0,0);
         print(X)
-        Y = qforte.make_gate('Y',0,0);
+        Y = qforte.'Y',0,0);
         print(Y)
-        Z = qforte.make_gate('Z',0,0);
+        Z = qforte.'Z',0,0);
         print(Z)
-        H = qforte.make_gate('H',0,0);
+        H = qforte.'H',0,0);
         print(H)
-        R = qforte.make_gate('R',0,0,0.1);
+        R = qforte.'R',0,0,0.1);
         print(R)
-        S = qforte.make_gate('S',0,0);
+        S = qforte.'S',0,0);
         print(S)
-        T = qforte.make_gate('T',0,0);
+        T = qforte.'T',0,0);
         print(T)
-        cX = qforte.make_gate('cX',0,1);
+        cX = qforte.'cX',0,1);
         print(cX)
-        cY = qforte.make_gate('cY',0,1);
+        cY = qforte.'cY',0,1);
         print(cY)
-        cZ = qforte.make_gate('cZ',0,1);
+        cZ = qforte.'cZ',0,1);
         print(cZ)
        # qcircuit = qforte.QuantumCircuit()
        # qcircuit.add_gate(qg)
@@ -236,11 +240,11 @@ class GatesTests(unittest.TestCase):
         trial_state = qforte.QuantumComputer(4)
 
         trial_prep = [None]*5
-        trial_prep[0] = qforte.make_gate('H',0,0)
-        trial_prep[1] = qforte.make_gate('H',1,1)
-        trial_prep[2] = qforte.make_gate('H',2,2)
-        trial_prep[3] = qforte.make_gate('H',3,3)
-        trial_prep[4] = qforte.make_gate('cX',0,1)
+        trial_prep[0] = qforte.'H',0,0)
+        trial_prep[1] = qforte.'H',1,1)
+        trial_prep[2] = qforte.'H',2,2)
+        trial_prep[3] = qforte.'H',3,3)
+        trial_prep[4] = qforte.'cX',0,1)
 
         trial_circ = qforte.QuantumCircuit()
 
@@ -252,10 +256,10 @@ class GatesTests(unittest.TestCase):
         trial_state.apply_circuit(trial_circ)
 
         # gates needed for [a1^ a2] operator
-        X1 = qforte.make_gate('X',1,1)
-        X2 = qforte.make_gate('X',2,2)
-        Y1 = qforte.make_gate('Y',1,1)
-        Y2 = qforte.make_gate('Y',2,2)
+        X1 = qforte.'X',1,1)
+        X2 = qforte.'X',2,2)
+        Y1 = qforte.'Y',1,1)
+        Y2 = qforte.'Y',2,2)
 
         # initialize circuits to make operator
         circ1 = qforte.QuantumCircuit()

--- a/tests/gates_test.py
+++ b/tests/gates_test.py
@@ -13,7 +13,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        X = qforte.'X',0);
+        X = qforte.gate('X',0);
         # test X|0> = |1>
         computer.apply_gate(X)
         coeff0 = computer.coeff(basis0)
@@ -35,7 +35,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        Y = qforte.'Y',0,0);
+        Y = qforte.gate('Y',0,0);
         # test Y|0> = i|1>
         computer.apply_gate(Y)
         coeff0 = computer.coeff(basis0)
@@ -57,7 +57,7 @@ class GatesTests(unittest.TestCase):
         basis0 = make_basis('0')
         basis1 = make_basis('1')
         computer = qforte.QuantumComputer(nqubits)
-        Z = qforte.'Z',0,0);
+        Z = qforte.gate('Z',0,0);
         # test Z|0> = |0>
         computer.apply_gate(Z)
         coeff0 = computer.coeff(basis0)
@@ -80,7 +80,7 @@ class GatesTests(unittest.TestCase):
         basis2 = make_basis('10') # basis2:|01>
         basis3 = make_basis('11') # basis3:|11>
         computer = qforte.QuantumComputer(nqubits)
-        CNOT = qforte.'CNOT',0,1);
+        CNOT = qforte.gate('CNOT',0,1);
 
         # test CNOT|00> = |00>
         computer.set_state([(basis0,1.0)])
@@ -131,7 +131,7 @@ class GatesTests(unittest.TestCase):
         self.assertAlmostEqual(coeff3, 0.0 + 0.0j)
 
         with self.assertRaises(ValueError) as context:
-            qforte.'CNOT',0,1.0)
+            qforte.gate('CNOT',0,1.0)
             self.assertTrue(')' in str(context.exception))
 
     def test_cY_gate(self):
@@ -142,7 +142,7 @@ class GatesTests(unittest.TestCase):
         basis2 = make_basis('10') # basis2:|01>
         basis3 = make_basis('11') # basis3:|11>
         computer = qforte.QuantumComputer(nqubits)
-        cY = qforte.'cY',0,1);
+        cY = qforte.gate('cY',0,1);
 
         # test cY|00> = |00>
         computer.set_state([(basis0,1.0)])
@@ -198,25 +198,25 @@ class GatesTests(unittest.TestCase):
         # test that 1 - 1 = 0
 
         # print('\n'.join(qc.str()))
-        X = qforte.'X',0,0);
+        X = qforte.gate('X',0,0);
         print(X)
-        Y = qforte.'Y',0,0);
+        Y = qforte.gate('Y',0,0);
         print(Y)
-        Z = qforte.'Z',0,0);
+        Z = qforte.gate('Z',0,0);
         print(Z)
-        H = qforte.'H',0,0);
+        H = qforte.gate('H',0,0);
         print(H)
-        R = qforte.'R',0,0,0.1);
+        R = qforte.gate('R',0,0,0.1);
         print(R)
-        S = qforte.'S',0,0);
+        S = qforte.gate('S',0,0);
         print(S)
-        T = qforte.'T',0,0);
+        T = qforte.gate('T',0,0);
         print(T)
-        cX = qforte.'cX',0,1);
+        cX = qforte.gate('cX',0,1);
         print(cX)
-        cY = qforte.'cY',0,1);
+        cY = qforte.gate('cY',0,1);
         print(cY)
-        cZ = qforte.'cZ',0,1);
+        cZ = qforte.gate('cZ',0,1);
         print(cZ)
        # qcircuit = qforte.QuantumCircuit()
        # qcircuit.add_gate(qg)
@@ -240,11 +240,11 @@ class GatesTests(unittest.TestCase):
         trial_state = qforte.QuantumComputer(4)
 
         trial_prep = [None]*5
-        trial_prep[0] = qforte.'H',0,0)
-        trial_prep[1] = qforte.'H',1,1)
-        trial_prep[2] = qforte.'H',2,2)
-        trial_prep[3] = qforte.'H',3,3)
-        trial_prep[4] = qforte.'cX',0,1)
+        trial_prep[0] = qforte.gate('H',0,0)
+        trial_prep[1] = qforte.gate('H',1,1)
+        trial_prep[2] = qforte.gate('H',2,2)
+        trial_prep[3] = qforte.gate('H',3,3)
+        trial_prep[4] = qforte.gate('cX',0,1)
 
         trial_circ = qforte.QuantumCircuit()
 
@@ -256,10 +256,10 @@ class GatesTests(unittest.TestCase):
         trial_state.apply_circuit(trial_circ)
 
         # gates needed for [a1^ a2] operator
-        X1 = qforte.'X',1,1)
-        X2 = qforte.'X',2,2)
-        Y1 = qforte.'Y',1,1)
-        Y2 = qforte.'Y',2,2)
+        X1 = qforte.gate('X',1,1)
+        X2 = qforte.gate('X',2,2)
+        Y1 = qforte.gate('Y',1,1)
+        Y2 = qforte.gate('Y',2,2)
 
         # initialize circuits to make operator
         circ1 = qforte.QuantumCircuit()

--- a/tests/trotter_test.py
+++ b/tests/trotter_test.py
@@ -59,10 +59,10 @@ class ExperimentTests(unittest.TestCase):
         qc = qforte.QuantumComputer(3)
 
         # build HF state
-        qc.apply_gate(qforte.make_gate('X', 0, 0))
+        qc.apply_gate(qforte.gate('X', 0, 0))
 
         # put ancilla in |1> state
-        qc.apply_gate(qforte.make_gate('X', 2, 2))
+        qc.apply_gate(qforte.gate('X', 2, 2))
 
         # apply the troterized minus_iH
         qc.apply_circuit(Utrot)
@@ -80,7 +80,7 @@ class ExperimentTests(unittest.TestCase):
         qc = qforte.QuantumComputer(3)
 
         # build HF state
-        qc.apply_gate(qforte.make_gate('X', 0, 0))
+        qc.apply_gate(qforte.gate('X', 0, 0))
 
         # apply the troterized minus_iH
         qc.apply_circuit(Utrot)


### PR DESCRIPTION
This PR renames `qforte.make_gate() -> qforte.gate()` and allows `gate` to handle the following cases:

- `gate(type, control)`: only for single qubit gates
- `gate(type, control, target)`: only for two-qubit gates that require no parameters
- `gate(type, control, parameter)`: only for single qubit gates
- `gate(type, control, target,parameter)`: for any type of gate (there is an extra layer of checks at the C++ side)

- [x] All tests pass.
