### PR TITLE
Remove of hard dep

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -12,23 +12,26 @@ from qforte.helper.operator_helper import build_from_openfermion, build_sqop_fro
 from qforte.system.molecular_info import Molecule
 from qforte.utils import transforms as tf
 
-from openfermion.ops import FermionOperator, QubitOperator
 
 try:
     from openfermion.chem import MolecularData
-except:
-    from openfermion.hamiltonians import MolecularData
-
-from openfermion.transforms import get_fermion_operator, jordan_wigner
-
-try:
+    from openfermion.transforms import get_fermion_operator, jordan_wigner
     from openfermion.transforms.opconversions import normal_ordered
     from openfermion.transforms.repconversions import freeze_orbitals
     from openfermion.utils import hermitian_conjugated
 except:
-    from openfermion.utils import hermitian_conjugated, normal_ordered, freeze_orbitals
+    try:
+        from openfermion.hamiltonians import MolecularData
+        from openfermion.transforms import get_fermion_operator, jordan_wigner
+        from openfermion.utils import hermitian_conjugated, normal_ordered, freeze_orbitals
+    except:
+        use_openfermion = False
 
-from openfermionpsi4 import run_psi4
+
+try:
+    from openfermionpsi4 import run_psi4
+except:
+    use_openfermion_psi4 = False
 
 import json
 

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -48,7 +48,7 @@ except:
 def create_openfermion_mol(**kwargs):
     """Builds a Molecule object using openfermion as a backend.
     By default, it runs a scf calcuation and stores the qubit hamiltonian
-    (hamiltonian in poly word representation).
+    (hamiltonian in Pauli word representation).
 
     Variables
     ---------

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -86,6 +86,12 @@ def create_openfermion_mol(**kwargs):
         The qforte Molecule object which holds the molecular information.
     """
 
+    if not use_openfermion:
+        raise ImportError("openfermion was not imported correctely.")
+
+    if not use_openfermion_psi4:
+        raise ImportError("openfermion-psi4 was not imported correctely.")
+
     qforte_mol = Molecule(mol_geometry = kwargs['mol_geometry'],
                                basis = kwargs['basis'],
                                multiplicity = kwargs['multiplicity'],

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -19,17 +19,20 @@ try:
     from openfermion.transforms.opconversions import normal_ordered
     from openfermion.transforms.repconversions import freeze_orbitals
     from openfermion.utils import hermitian_conjugated
+    use_openfermion = True
 except:
     try:
         from openfermion.hamiltonians import MolecularData
         from openfermion.transforms import get_fermion_operator, jordan_wigner
         from openfermion.utils import hermitian_conjugated, normal_ordered, freeze_orbitals
+        use_openfermion = True
     except:
         use_openfermion = False
 
 
 try:
     from openfermionpsi4 import run_psi4
+    use_openfermion_psi4 = True
 except:
     use_openfermion_psi4 = False
 

--- a/src/qforte/helper/operator_helper.py
+++ b/src/qforte/helper/operator_helper.py
@@ -1,5 +1,4 @@
 import qforte
-from openfermion.ops import QubitOperator
 import numpy as np
 
 def build_from_openfermion(OF_qubitops, time_evo_factor = 1.0):


### PR DESCRIPTION
## Description
This PR modifies the import structure such that qforte may be imported without installation of openfermion. 

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features and included a reference `output.ref` file
- [x] Removed comments in code and input files
- [x] Documented source code
- [x] Checked for redundant headers
- [x] Checked for consistency in the formatting of the output file
- [x] Documented new features in the manual
- [x] Ready to go!
