### PR TITLE
Remove Particle-Conserving Assumption

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -6,10 +6,9 @@ A brief description of the goals accomplished by this PR
 - [ ] Changes to compilation (if any)
 
 ## Checklist
-- [ ] Added/updated tests of new features and included a reference `output.ref` file
-- [ ] Removed comments in code and input files
+- [ ] Added/updated tests of new features
+- [ ] Removed comments in input files
 - [ ] Documented source code
-- [ ] Checked for redundant headers
+- [ ] Checked for redundant headers/imports
 - [ ] Checked for consistency in the formatting of the output file
-- [ ] Documented new features in the manual
 - [ ] Ready to go!

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -318,7 +318,7 @@ def create_psi_mol(**kwargs):
     # Build second quantized Hamiltonian
     nmo = np.shape(mo_oeis)[0]
     Hsq = qforte.SQOperator()
-    Hsq.add(p4_Enuc_ref, [])
+    Hsq.add(p4_Enuc_ref, [], [])
     for i in range(nmo):
         ia = i*2
         ib = i*2 + 1
@@ -326,8 +326,8 @@ def create_psi_mol(**kwargs):
             ja = j*2
             jb = j*2 + 1
 
-            Hsq.add(mo_oeis[i,j], [ia, ja])
-            Hsq.add(mo_oeis[i,j], [ib, jb])
+            Hsq.add(mo_oeis[i,j], [ia], [ja])
+            Hsq.add(mo_oeis[i,j], [ib], [jb])
 
             for k in range(nmo):
                 ka = k*2
@@ -337,14 +337,14 @@ def create_psi_mol(**kwargs):
                     lb = l*2 + 1
 
                     if(ia!=jb and kb != la):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb, kb, la] ) # abba
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb], [kb, la] ) # abba
                     if(ib!=ja and ka!=lb):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, ja, ka, lb] ) # baab
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, ja], [ka, lb] ) # baab
 
                     if(ia!=ja and ka!=la):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, ja, ka, la] ) # aaaa
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ia, ja], [ka, la] ) # aaaa
                     if(ib!=jb and kb!=lb):
-                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, jb, kb, lb] ) # bbbb
+                        Hsq.add( mo_teis[i,l,k,j]/2, [ib, jb], [kb, lb] ) # bbbb
 
     # Set attributes
     qforte_mol.set_nuclear_repulsion_energy(p4_Enuc_ref)
@@ -376,13 +376,13 @@ def create_external_mol(**kwargs):
 
     # build sq hamiltonian
     qforte_sq_hamiltonian = qforte.SQOperator()
-    qforte_sq_hamiltonian.add(external_data['scalar_energy']['data'], [])
+    qforte_sq_hamiltonian.add(external_data['scalar_energy']['data'], [], [])
 
     for p, q, h_pq in external_data['oei']['data']:
-        qforte_sq_hamiltonian.add(h_pq, [p,q])
+        qforte_sq_hamiltonian.add(h_pq, [p], [q])
 
     for p, q, r, s, h_pqrs in external_data['tei']['data']:
-        qforte_sq_hamiltonian.add(h_pqrs/4.0, [p,q,s,r]) # only works in C1 symmetry
+        qforte_sq_hamiltonian.add(h_pqrs/4.0, [p,q], [s,r]) # only works in C1 symmetry
 
     hf_reference = [0 for i in range(external_data['nso']['data'])]
     for n in range(external_data['na']['data'] + external_data['nb']['data']):

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -35,8 +35,6 @@ class QITE(Algorithm):
     _sig : QuantumOpPool
         The basis of operators allowed in a unitary evolution step.
     _sparseSb : bool
-    _sq_ham : SqOperator
-        The second-quantized, fermionic Hamiltonian
     _total_phase : complex
     _Uqite: QuantumCircuit
     _x_thresh : float
@@ -54,7 +52,6 @@ class QITE(Algorithm):
         self._beta = beta
         self._db = db
         self._nbeta = int(beta/db)+1
-        self._sq_ham = self._sys.get_sq_hamiltonian()
         self._expansion_type = expansion_type
         self._sparseSb = sparseSb
         self._total_phase = 1.0 + 0.0j

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -101,8 +101,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                 if( aa != ia ){
                     SQOperator temp1a;
-                    temp1a.add_term(+1.0, {aa, ia});
-                    temp1a.add_term(-1.0, {ia, aa});
+                    temp1a.add_term(+1.0, {aa}, {ia});
+                    temp1a.add_term(-1.0, {ia}, {aa});
                     temp1a.simplify();
                     if(temp1a.terms().size() > 0){
                         add_term(1.0, temp1a);
@@ -111,8 +111,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                 if( ab != ib ){
                     SQOperator temp1b;
-                    temp1b.add_term(+1.0, {ab, ib});
-                    temp1b.add_term(-1.0, {ib, ab});
+                    temp1b.add_term(+1.0, {ab}, {ib});
+                    temp1b.add_term(-1.0, {ib}, {ab});
                     temp1b.simplify();
                     if(temp1b.terms().size() > 0){
                         add_term(1.0, temp1b);
@@ -139,8 +139,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((aa != ba) && (ia != ja)){
                             SQOperator temp2aaaa;
-                            temp2aaaa.add_term(+1.0, {aa,ba,ia,ja});
-                            temp2aaaa.add_term(-1.0, {ja,ia,ba,aa});
+                            temp2aaaa.add_term(+1.0, {aa,ba}, {ia,ja});
+                            temp2aaaa.add_term(-1.0, {ja,ia}, {ba,aa});
                             temp2aaaa.simplify();
                             if(temp2aaaa.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2aaaa.terms()[0])[0], std::get<1>(temp2aaaa.terms()[0])[1], std::get<1>(temp2aaaa.terms()[0])[2], std::get<1>(temp2aaaa.terms()[0])[3]};
@@ -157,8 +157,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((ab != bb ) && (ib != jb)){
                             SQOperator temp2bbbb;
-                            temp2bbbb.add_term(+1.0, {ab,bb,ib,jb});
-                            temp2bbbb.add_term(-1.0, {jb,ib,bb,ab});
+                            temp2bbbb.add_term(+1.0, {ab,bb}, {ib,jb});
+                            temp2bbbb.add_term(-1.0, {jb,ib}, {bb,ab});
                             temp2bbbb.simplify();
                             if(temp2bbbb.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2bbbb.terms()[0])[0], std::get<1>(temp2bbbb.terms()[0])[1], std::get<1>(temp2bbbb.terms()[0])[2], std::get<1>(temp2bbbb.terms()[0])[3]};
@@ -175,8 +175,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((aa != bb) && (ia != jb)){
                             SQOperator temp2abab;
-                            temp2abab.add_term(+1.0, {aa,bb,ia,jb});
-                            temp2abab.add_term(-1.0, {jb,ia,bb,aa});
+                            temp2abab.add_term(+1.0, {aa,bb}, {ia,jb});
+                            temp2abab.add_term(-1.0, {jb,ia}, {bb,aa});
                             temp2abab.simplify();
                             if(temp2abab.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2abab.terms()[0])[0], std::get<1>(temp2abab.terms()[0])[1], std::get<1>(temp2abab.terms()[0])[2], std::get<1>(temp2abab.terms()[0])[3]};
@@ -193,8 +193,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((ab != ba) && (ib != ja)){
                             SQOperator temp2baba;
-                            temp2baba.add_term(+1.0, {ab,ba,ib,ja});
-                            temp2baba.add_term(-1.0, {ja,ib,ba,ab});
+                            temp2baba.add_term(+1.0, {ab,ba}, {ib,ja});
+                            temp2baba.add_term(-1.0, {ja,ib}, {ba,ab});
                             temp2baba.simplify();
                             if(temp2baba.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2baba.terms()[0])[0], std::get<1>(temp2baba.terms()[0])[1], std::get<1>(temp2baba.terms()[0])[2], std::get<1>(temp2baba.terms()[0])[3]};
@@ -211,8 +211,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((aa != bb) && (ib != ja)){
                             SQOperator temp2abba;
-                            temp2abba.add_term(+1.0, {aa,bb,ib,ja});
-                            temp2abba.add_term(-1.0, {ja,ib,bb,aa});
+                            temp2abba.add_term(+1.0, {aa,bb}, {ib,ja});
+                            temp2abba.add_term(-1.0, {ja,ib}, {bb,aa});
                             temp2abba.simplify();
                             if(temp2abba.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2abba.terms()[0])[0], std::get<1>(temp2abba.terms()[0])[1], std::get<1>(temp2abba.terms()[0])[2], std::get<1>(temp2abba.terms()[0])[3]};
@@ -230,8 +230,8 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         if((ab != ba) && (ia != jb)){
                             SQOperator temp2baab;
-                            temp2baab.add_term(+1.0, {ab,ba,ia,jb});
-                            temp2baab.add_term(-1.0, {jb,ia,ba,ab});
+                            temp2baab.add_term(+1.0, {ab,ba}, {ia,jb});
+                            temp2baab.add_term(-1.0, {jb,ia}, {ba,ab});
                             temp2baab.simplify();
                             if(temp2baab.terms().size() > 0){
                                 std::vector<size_t> vtemp {std::get<1>(temp2baab.terms()[0])[0], std::get<1>(temp2baab.terms()[0])[1], std::get<1>(temp2baab.terms()[0])[2], std::get<1>(temp2baab.terms()[0])[3]};
@@ -334,13 +334,12 @@ void SQOpPool::fill_pool(std::string pool_type){
                     }
 
                     if(total_parity==1){
-                        particles.insert(particles.end(), holes.begin(), holes.end());
-                        std::vector<size_t> particles_adj (particles.rbegin(), particles.rend());
-
                         // need i, j, a, b
                         SQOperator t_temp;
-                        t_temp.add_term(+1.0, particles);
-                        t_temp.add_term(-1.0, particles_adj);
+                        t_temp.add_term(+1.0, particles, holes);
+                        std::vector<size_t> rparticles(particles.rbegin(), particles.rend());
+                        std::vector<size_t> rholes(holes.rbegin(), holes.rend());
+                        t_temp.add_term(-1.0, rholes, rparticles);
                         t_temp.simplify();
                         add_term(1.0, t_temp);
                     }
@@ -357,17 +356,17 @@ void SQOpPool::fill_pool(std::string pool_type){
                 size_t ab = 2*nocc_ + 2*a+1;
 
                 SQOperator temp1;
-                temp1.add_term(+1.0/std::sqrt(2), {aa, ia});
-                temp1.add_term(+1.0/std::sqrt(2), {ab, ib});
+                temp1.add_term(+1.0/std::sqrt(2), {aa}, {ia});
+                temp1.add_term(+1.0/std::sqrt(2), {ab}, {ib});
 
-                temp1.add_term(-1.0/std::sqrt(2), {ia, aa});
-                temp1.add_term(-1.0/std::sqrt(2), {ib, ab});
+                temp1.add_term(-1.0/std::sqrt(2), {ia}, {aa});
+                temp1.add_term(-1.0/std::sqrt(2), {ib}, {ab});
 
                 temp1.simplify();
 
                 std::complex<double> temp1_norm(0.0, 0.0);
                 for (const auto& term : temp1.terms()){
-                    temp1_norm += std::norm(term.first);
+                    temp1_norm += std::norm(std::get<0>(term));
                 }
                 temp1.mult_coeffs(1.0/std::sqrt(temp1_norm));
                 add_term(1.0, temp1);
@@ -392,70 +391,70 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                         SQOperator temp2a;
                         if((aa != ba) && (ia != ja)){
-                            temp2a.add_term(2.0/std::sqrt(12), {aa,ba,ia,ja});
+                            temp2a.add_term(2.0/std::sqrt(12), {aa,ba}, {ia,ja});
                         }
                         if((ab != bb ) && (ib != jb)){
-                            temp2a.add_term(2.0/std::sqrt(12), {ab,bb,ib,jb});
+                            temp2a.add_term(2.0/std::sqrt(12), {ab,bb}, {ib,jb});
                         }
                         if((aa != bb) && (ia != jb)){
-                            temp2a.add_term(1.0/std::sqrt(12), {aa,bb,ia,jb});
+                            temp2a.add_term(1.0/std::sqrt(12), {aa,bb}, {ia,jb});
                         }
                         if((ab != ba) && (ib != ja)){
-                            temp2a.add_term(1.0/std::sqrt(12), {ab,ba,ib,ja});
+                            temp2a.add_term(1.0/std::sqrt(12), {ab,ba}, {ib,ja});
                         }
                         if((aa != bb) && (ib != ja)){
-                            temp2a.add_term(1.0/std::sqrt(12), {aa,bb,ib,ja});
+                            temp2a.add_term(1.0/std::sqrt(12), {aa,bb}, {ib,ja});
                         }
                         if((ab != ba) && (ia != jb)){
-                            temp2a.add_term(1.0/std::sqrt(12), {ab,ba,ia,jb});
+                            temp2a.add_term(1.0/std::sqrt(12), {ab,ba}, {ia,jb});
                         }
 
                         // hermitian conjugate
                         if((ja != ia) && (ba != aa)){
-                            temp2a.add_term(-2.0/std::sqrt(12), {ja,ia,ba,aa});
+                            temp2a.add_term(-2.0/std::sqrt(12), {ja,ia}, {ba,aa});
                         }
                         if((jb != ib ) && (bb != ab)){
-                            temp2a.add_term(-2.0/std::sqrt(12), {jb,ib,bb,ab});
+                            temp2a.add_term(-2.0/std::sqrt(12), {jb,ib}, {bb,ab});
                         }
                         if((jb != ia) && (bb != aa)){
-                            temp2a.add_term(-1.0/std::sqrt(12), {jb,ia,bb,aa});
+                            temp2a.add_term(-1.0/std::sqrt(12), {jb,ia}, {bb,aa});
                         }
                         if((ja != ib) && (ba != ab)){
-                            temp2a.add_term(-1.0/std::sqrt(12), {ja,ib,ba,ab});
+                            temp2a.add_term(-1.0/std::sqrt(12), {ja,ib}, {ba,ab});
                         }
                         if((ja != ib) && (bb != aa)){
-                            temp2a.add_term(-1.0/std::sqrt(12), {ja,ib,bb,aa});
+                            temp2a.add_term(-1.0/std::sqrt(12), {ja,ib}, {bb,aa});
                         }
                         if((jb != ia) && (ba != ab)){
-                            temp2a.add_term(-1.0/std::sqrt(12), {jb,ia,ba,ab});
+                            temp2a.add_term(-1.0/std::sqrt(12), {jb,ia}, {ba,ab});
                         }
 
                         SQOperator temp2b;
                         if((aa != bb) && (ia != jb)){
-                            temp2b.add_term(0.5, {aa,bb,ia,jb});
+                            temp2b.add_term(0.5, {aa,bb}, {ia,jb});
                         }
                         if((ab != ba) && (ib != ja)){
-                            temp2b.add_term(0.5, {ab,ba,ib,ja});
+                            temp2b.add_term(0.5, {ab,ba}, {ib,ja});
                         }
                         if((aa != bb) && (ib != ja)){
-                            temp2b.add_term(-0.5, {aa,bb,ib,ja});
+                            temp2b.add_term(-0.5, {aa,bb}, {ib,ja});
                         }
                         if((ab != ba) && (ia != jb)){
-                            temp2b.add_term(-0.5, {ab,ba,ia,jb});
+                            temp2b.add_term(-0.5, {ab,ba}, {ia,jb});
                         }
 
                         // hermetian conjugate
                         if((jb != ia) && (bb != aa)){
-                            temp2b.add_term(-0.5, {jb,ia,bb,aa});
+                            temp2b.add_term(-0.5, {jb,ia}, {bb,aa});
                         }
                         if((ja != ib) && (ba != ab)){
-                            temp2b.add_term(-0.5, {ja,ib,ba,ab});
+                            temp2b.add_term(-0.5, {ja,ib}, {ba,ab});
                         }
                         if((ja != ib) && (bb != aa)){
-                            temp2b.add_term(0.5, {ja,ib,bb,aa});
+                            temp2b.add_term(0.5, {ja,ib}, {bb,aa});
                         }
                         if((jb != ia) && (ba != ab)){
-                            temp2b.add_term(0.5, {jb,ia,ba,ab});
+                            temp2b.add_term(0.5, {jb,ia}, {ba,ab});
                         }
 
                         temp2a.simplify();
@@ -464,10 +463,10 @@ void SQOpPool::fill_pool(std::string pool_type){
                         std::complex<double> temp2a_norm(0.0, 0.0);
                         std::complex<double> temp2b_norm(0.0, 0.0);
                         for (const auto& term : temp2a.terms()){
-                            temp2a_norm += std::norm(term.first);
+                            temp2a_norm += std::norm(std::get<0>(term));
                         }
                         for (const auto& term : temp2b.terms()){
-                            temp2b_norm += std::norm(term.first);
+                            temp2b_norm += std::norm(std::get<0>(term));
                         }
                         temp2a.mult_coeffs(1.0/std::sqrt(temp2a_norm));
                         temp2b.mult_coeffs(1.0/std::sqrt(temp2b_norm));
@@ -482,14 +481,6 @@ void SQOpPool::fill_pool(std::string pool_type){
                 }
             }
         }
-    } else if(pool_type == "test"){
-        SQOperator A;
-        A.add_term(+2.0, {1,2,4,3});
-        A.add_term(-2.0, {2,4});
-        A.add_term(-2.0, {3,4,2,1});
-        A.add_term(+2.0, {4,2});
-        add_term(-0.25, A);
-        add_term(+0.75, A);
     } else {
         throw std::invalid_argument( "Invalid pool_type specified." );
     }
@@ -505,18 +496,7 @@ std::string SQOpPool::str() const{
         s.push_back("<-----\n");
         s.push_back(to_string(term.first));
         s.push_back("[\n");
-        for (const auto& sub_term : term.second.terms()) {
-            int nbody = sub_term.second.size() / 2.0;
-            s.push_back(to_string(sub_term.first));
-            s.push_back("(");
-            for (int k=0; k<nbody; k++ ) {
-                s.push_back(std::to_string(sub_term.second[k]) + "^");
-            }
-            for (int k=nbody; k<2*nbody; k++ ) {
-                s.push_back(std::to_string(sub_term.second[k]));
-            }
-            s.push_back(")\n");
-        }
+        s.push_back(term.second.str());
         s.push_back("]\n\n");
         counter++;
     }

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -49,7 +49,7 @@ int SQOperator::canonicalize_helper(std::vector<size_t>& op_list) const {
         for (int i = 0; i < length; i++) {
             op_list[i] = temp_op[temp[i]];
         }
-        return (permutive_sign_change(temp)) ? -1 : 1;
+        return (permutation_phase(temp)) ? -1 : 1;
     }
 
 }
@@ -84,7 +84,7 @@ void SQOperator::simplify() {
     }
 }
 
-bool SQOperator::permutive_sign_change(std::vector<int> p) const {
+bool SQOperator::permutation_phase(std::vector<int> p) const {
     std::vector<int> a(p.size());
     std::iota (std::begin(a), std::end(a), 0);
     size_t cnt = 0;

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <stdexcept>
+#include <tuple>
 
 #include "helpers.h"
 #include "quantum_gate.h"
@@ -6,71 +8,55 @@
 #include "quantum_operator.h"
 #include "sq_operator.h"
 
-#include <stdexcept>
-#include <algorithm>
-
-void SQOperator::add_term(std::complex<double> circ_coeff, const std::vector<size_t>& ac_ops) {
-    if ((ac_ops.size() % 2) != 0) throw std::invalid_argument("Term must have N creators and N annihilators, but received odd number of orbital indices");
-    terms_.push_back(std::make_pair(circ_coeff, ac_ops));
+void SQOperator::add_term(std::complex<double> circ_coeff, const std::vector<size_t>& cre_ops, const std::vector<size_t>& ann_ops) {
+    terms_.push_back(std::make_tuple(circ_coeff, cre_ops, ann_ops));
 }
 
 void SQOperator::add_op(const SQOperator& qo) {
-    for (const auto& term : qo.terms()) {
-        terms_.push_back(std::make_pair(term.first, term.second));
-    }
+    terms_.insert(terms_.end(), qo.terms().begin(), qo.terms().end());
 }
 
 void SQOperator::set_coeffs(const std::vector<std::complex<double>>& new_coeffs) {
     if(new_coeffs.size() != terms_.size()){
         throw std::invalid_argument( "number of new coefficients for quantum operator must equal " );
     }
-    for (size_t l = 0; l < new_coeffs.size(); l++){
-        terms_[l].first = new_coeffs[l];
+    for (auto l = 0; l < new_coeffs.size(); l++) {
+        std::get<0>(terms_[l]) = new_coeffs[l];
     }
 }
 
 void SQOperator::mult_coeffs(const std::complex<double>& multiplier) {
-    for (size_t l = 0; l < terms_.size(); l++){
-        terms_[l].first *= multiplier;
+    for (auto term : terms_){
+        std::get<0>(term) *= multiplier;
     }
 }
 
-const std::vector<std::pair<std::complex<double>, std::vector<size_t>>>& SQOperator::terms() const {
+const std::vector<std::tuple<std::complex<double>, std::vector<size_t>, std::vector<size_t>>>& SQOperator::terms() const {
     return terms_;
 }
 
-void SQOperator::canonical_order_single_term(std::pair< std::complex<double>, std::vector<size_t>>& term ){
-    if((term.second.size() % 2) != 0){
-        throw std::invalid_argument( "sq operator term must have equal number of anihilators and creators.");
-    }
-    int nbody = term.second.size() / 2.0;
-    if (nbody >= 2) {
-        auto term_temp = term;
-        std::vector<int> a(nbody);
-        std::iota(std::begin(a), std::end(a), 0);
-        std::vector<int> b(nbody);
-        std::iota(std::begin(b), std::end(b), 0);
-        // get permutations for creators then reorder
-        std::sort(a.begin(), a.end(),
+int SQOperator::canonicalize_helper(std::vector<size_t>& op_list) const {
+    auto temp_op = op_list;
+    auto length = temp_op.size();
+    {
+        std::vector<int> temp(length);
+        std::iota(std::begin(temp), std::end(temp), 0);
+        std::sort(temp.begin(), temp.end(),
             [&](const int& i, const int& j) {
-                return (term_temp.second[i] > term_temp.second[j]);
+                return (temp_op[i] > temp_op[j]);
             }
         );
-        for (int ai=0; ai < nbody; ai++){
-            term.second[ai] = term_temp.second[a[ai]];
+        for (int i = 0; i < length; i++) {
+            op_list[i] = temp_op[temp[i]];
         }
-        if (permutive_sign_change(a)) { term.first *= -1.0; }
-        // same as above but for annihilators
-        std::sort(b.begin(), b.end(),
-            [&](const int& i, const int& j) {
-                return (term_temp.second[i+nbody] > term_temp.second[j+nbody]);
-            }
-        );
-        for (int bi=0; bi < nbody; bi++){
-            term.second[bi+nbody] = term_temp.second[b[bi]+nbody];
-        }
-        if (permutive_sign_change(b)) { term.first *= -1.0; }
+        return (permutive_sign_change(temp)) ? -1 : 1;
     }
+
+}
+
+void SQOperator::canonical_order_single_term(std::tuple< std::complex<double>, std::vector<size_t>, std::vector<size_t>>& term ){
+    std::get<0>(term) *= canonicalize_helper(std::get<1>(term));
+    std::get<0>(term) *= canonicalize_helper(std::get<2>(term));
 }
 
 void SQOperator::canonical_order() {
@@ -81,23 +67,24 @@ void SQOperator::canonical_order() {
 
 void SQOperator::simplify() {
     canonical_order();
-    std::map<std::vector<size_t>, std::complex<double>> uniqe_trms;
+    std::map<std::pair<std::vector<size_t>, std::vector<size_t>>, std::complex<double>> unique_terms;
     for (const auto& term : terms_) {
-        if ( uniqe_trms.find(term.second) == uniqe_trms.end() ) {
-            uniqe_trms.insert(std::make_pair(term.second, term.first));
+        auto pair = std::make_pair(std::get<1>(term), std::get<2>(term));
+        if (unique_terms.find(pair) == unique_terms.end() ) {
+            unique_terms.insert(std::make_pair(pair, std::get<0>(term)));
         } else {
-            uniqe_trms[term.second] += term.first;
+            unique_terms[pair] += std::get<0>(term);
         }
     }
     terms_.clear();
-    for (const auto &uniqe_trm : uniqe_trms){
-        if (std::abs(uniqe_trm.second) > 1.0e-16){
-            terms_.push_back(std::make_pair(uniqe_trm.second, uniqe_trm.first));
+    for (const auto &unique_term : unique_terms){
+        if (std::abs(unique_term.second) > 1.0e-16){
+            terms_.push_back(std::make_tuple(unique_term.second, unique_term.first.first, unique_term.first.second));
         }
     }
 }
 
-bool SQOperator::permutive_sign_change(std::vector<int> p) {
+bool SQOperator::permutive_sign_change(std::vector<int> p) const {
     std::vector<int> a(p.size());
     std::iota (std::begin(a), std::end(a), 0);
     size_t cnt = 0;
@@ -115,64 +102,60 @@ bool SQOperator::permutive_sign_change(std::vector<int> p) {
     }
 }
 
-QuantumOperator SQOperator::jw_transform() {
+void SQOperator::jw_helper(QuantumOperator& holder, const std::vector<size_t>& operators, bool creator) const {
     std::complex<double> halfi(0.0, 0.5);
-    simplify(); // This isn't needed for the logic - just an efficiency optimization.
+    if (creator) { halfi *= -1; };
+
+    for (const auto& sq_op : operators) {
+        QuantumOperator temp;
+        QuantumCircuit Xcirc;
+        QuantumCircuit Ycirc;
+
+        for (int k = 0; k < sq_op; k++) {
+            Xcirc.add_gate(make_gate("Z", k, k));
+            Ycirc.add_gate(make_gate("Z", k, k));
+        }
+
+        Xcirc.add_gate(make_gate("X", sq_op, sq_op));
+        Ycirc.add_gate(make_gate("Y", sq_op, sq_op));
+        temp.add_term(0.5, Xcirc);
+        temp.add_term(halfi, Ycirc);
+
+        if (holder.terms().size() == 0) {
+            holder.add_op(temp);
+        } else {
+            holder.operator_product(temp);
+        }
+    }
+}
+
+QuantumOperator SQOperator::jw_transform() {
+    simplify();
     QuantumOperator qo;
 
     for (const auto& fermion_operator : terms_) {
-        if((fermion_operator.second.size() % 2) != 0){
-            throw std::invalid_argument( "sq operator term must have equal number of annihilators and creators. This error should be unreachable - debugging QForte needed.");
-        }
-        int nbody = fermion_operator.second.size() / 2.0;
+        auto cre_length = std::get<1>(fermion_operator).size();
+        auto ann_length = std::get<2>(fermion_operator).size();
 
-        if (nbody == 0) {
+        if (cre_length == 0 && ann_length == 0) {
             // Scalars need special logic.
             QuantumCircuit scalar_circ;
             QuantumOperator scalar_op;
-            scalar_op.add_term(fermion_operator.first, scalar_circ);
+            scalar_op.add_term(std::get<0>(fermion_operator), scalar_circ);
             qo.add_op(scalar_op);
             continue;
         }
+
         QuantumOperator temp1;
-        for (int ai=0; ai<2*nbody; ai++) {
-            QuantumOperator temp2;
-            // Our qubit operator is (X +/- i Y) phase-factor-Z gates.
-            // We need two circuits in our linear combination.
-            QuantumCircuit Xcirc;
-            QuantumCircuit Ycirc;
+        jw_helper(temp1, std::get<1>(fermion_operator), true);
+        jw_helper(temp1, std::get<2>(fermion_operator), false);
 
-            // Z gates for the phase factor
-            for(int k=0; k<fermion_operator.second[ai]; k++){
-                Xcirc.add_gate(make_gate("Z", k, k));
-                Ycirc.add_gate(make_gate("Z", k, k));
-            }
-
-            Xcirc.add_gate(make_gate("X", fermion_operator.second[ai], fermion_operator.second[ai]));
-            Ycirc.add_gate(make_gate("Y", fermion_operator.second[ai], fermion_operator.second[ai]));
-            temp2.add_term(0.5, Xcirc);
-
-            // TODO: Remove below code's assumptions of vacuum-normal and particle-conserving.
-            // Will certainly require changing the innards of SQOperator.
-            if(ai < nbody){
-                // We have an annihilation operator.
-                temp2.add_term(-halfi, Ycirc);
-            } else {
-                // We have a creation operator.
-                temp2.add_term(halfi, Ycirc);
-            }
-
-            if (ai == 0) {
-                temp1.add_op(temp2);
-            } else {
-                temp1.operator_product(temp2);
-            }
-        }
-        temp1.mult_coeffs(fermion_operator.first);
+        temp1.mult_coeffs(std::get<0>(fermion_operator));
         qo.add_op(temp1);
     }
+
     qo.simplify();
-    // Consider also standard ordering these?
+
     return qo;
 }
 
@@ -180,14 +163,13 @@ std::string SQOperator::str() const {
     std::vector<std::string> s;
     s.push_back("");
     for (const auto& term : terms_) {
-        int nbody = term.second.size() / 2.0;
-        s.push_back(to_string(term.first));
+        s.push_back(to_string(std::get<0>(term)));
         s.push_back("(");
-        for (int k=0; k<nbody; k++ ) {
-            s.push_back(std::to_string(term.second[k]) + "^");
+        for (auto k: std::get<1>(term)) {
+            s.push_back(std::to_string(k) + "^");
         }
-        for (int k=nbody; k<2*nbody; k++ ) {
-            s.push_back(std::to_string(term.second[k]));
+        for (auto k: std::get<2>(term)) {
+            s.push_back(std::to_string(k));
         }
         s.push_back(")\n");
     }

--- a/src/qforte/sq_operator.h
+++ b/src/qforte/sq_operator.h
@@ -19,12 +19,8 @@ class SQOperator {
     /// default constructor: creates an empty second quantized operator
     SQOperator() {}
 
-    /// TODO: implement
-    /// build from a string of open fermion qubit operators
-    // void build_from_openferm_str(std::string op) {}
-
-    /// add one product of anihilators and/or creators to the second quantized operator
-    void add_term(std::complex<double> coeff, const std::vector<size_t>& ac_ops);
+    /// add one product of annihilators and/or creators to the second quantized operator
+    void add_term(std::complex<double> coeff, const std::vector<size_t>& cre_ops, const std::vector<size_t>& ann_ops);
 
     /// add an second quantized operator to the second quantized operator
     void add_op(const SQOperator& sqo);
@@ -36,11 +32,11 @@ class SQOperator {
     void mult_coeffs(const std::complex<double>& multiplier);
 
     /// return a vector of terms and their coefficients
-    const std::vector<std::pair< std::complex<double>, std::vector<size_t>>>& terms() const;
+    const std::vector<std::tuple< std::complex<double>, std::vector<size_t>, std::vector<size_t>>>& terms() const;
 
     /// Put a single term into "canonical" form. Canonical form orders orbital indices
     /// descending.
-    void canonical_order_single_term(std::pair< std::complex<double>, std::vector<size_t>>& term );
+    void canonical_order_single_term(std::tuple< std::complex<double>, std::vector<size_t>, std::vector<size_t>>& term );
 
     /// Canonicalize each term. The order of the terms is unaffected.
     void canonical_order();
@@ -59,10 +55,16 @@ class SQOperator {
     /// The linear combination of second quantized operators. Stored in pairs of
     /// coefficients, and then a vector of N created indices, followed by N annihilated indices.
     /// Orbital indices start at zero.
-    std::vector<std::pair< std::complex<double>, std::vector<size_t>>> terms_;
+    std::vector<std::tuple< std::complex<double>, std::vector<size_t>, std::vector<size_t>>> terms_;
 
     /// Calculate the parity of permutation p
-    bool permutive_sign_change(std::vector<int> p);
+    bool permutive_sign_change(std::vector<int> p) const;
+
+    int canonicalize_helper(std::vector<size_t>& op_list) const;
+
+    /// If operators is a vector of orbital indices, add the corresponding creator
+    /// or annihilation qubit operators to holder.
+    void jw_helper(QuantumOperator& holder, const std::vector<size_t>& operators, bool creator) const;
 };
 
 #endif // _sq_operator_h_

--- a/src/qforte/sq_operator.h
+++ b/src/qforte/sq_operator.h
@@ -12,14 +12,25 @@ class QuantumGate;
 class QuantumOperator;
 
 class SQOperator {
-    /* A SQOperator is a linear combination (over C) of vaccuum-normal, particle-conserving
-     * products of fermionic second quantized operators.
+    /* A SQOperator is a linear combination (over C) of vaccuum-normal products of fermionic
+     * second quantized operators.
+     * The significance of the linear combination is context-dependent, but it should refer
+     * to a "basis combination" in some sense, i.e., antihermitian combination for UCC,
+     * spin-adapted combination for closed-shell systems, a single operator for traditional CC.
+     *
+     * All storage, printing, and input of summands in the combination takes tuples of the following form:
+     * (1) coefficient
+     * (2) vector of orbital-indices of creation operators
+     * (3) vector of orbital-indices of annihilation operators,
+     * All orbital indices start at zero.
+     * Index vectors are lexicographic, i.e., std::tuple<1, {p, q}, {s, r}> means 1 * p^ q^ s r.
      */
   public:
     /// default constructor: creates an empty second quantized operator
     SQOperator() {}
 
-    /// add one product of annihilators and/or creators to the second quantized operator
+    /// add one product of annihilators and/or creators to this second quantized operator
+    /// Input is required in the same format as storage. See terms_ for details.
     void add_term(std::complex<double> coeff, const std::vector<size_t>& cre_ops, const std::vector<size_t>& ann_ops);
 
     /// add an second quantized operator to the second quantized operator
@@ -52,13 +63,11 @@ class SQOperator {
     std::string str() const;
 
   private:
-    /// The linear combination of second quantized operators. Stored in pairs of
-    /// coefficients, and then a vector of N created indices, followed by N annihilated indices.
-    /// Orbital indices start at zero.
+    /// The linear combination of second quantized operators. Stored as a tuple of
     std::vector<std::tuple< std::complex<double>, std::vector<size_t>, std::vector<size_t>>> terms_;
 
     /// Calculate the parity of permutation p
-    bool permutive_sign_change(std::vector<int> p) const;
+    bool permutation_phase(std::vector<int> p) const;
 
     int canonicalize_helper(std::vector<size_t>& op_list) const;
 

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -287,13 +287,14 @@ class SPQE(UCCPQE):
             # occ => i,j,k,...
             # vir => a,b,c,...
             # sq_op is 1.0(a^ b^ i j) - 1.0(j^ i^ b a)
-            temp_idx = sq_op.terms()[0][1][-1]
+            temp_idx = sq_op.terms()[0][2][-1]
             if temp_idx < int(sum(self._ref)/2): # if temp_idx is an occupid idx
-                sq_sub_tamp ,sq_sub_top = sq_op.terms()[0]
+                sq_creators = sq_op.terms()[0][1]
+                sq_annihilators = sq_op.terms()[0][2]
             else:
-                sq_sub_tamp ,sq_sub_top = sq_op.terms()[1]
+                sq_creators = sq_op.terms()[0][2]
+                sq_annihilators = sq_op.terms()[0][1]
 
-            nbody = int(len(sq_sub_top) / 2)
             destroyed = False
             denom = 1.0
 
@@ -302,20 +303,20 @@ class SPQE(UCCPQE):
                 basis_I.set_bit(k, occ)
 
             # loop over anihilators
-            for p in reversed(range(nbody, 2*nbody)):
-                if( basis_I.get_bit(sq_sub_top[p]) == 0):
+            for p in reversed(sq_annihilators):
+                if( basis_I.get_bit(p) == 0):
                     destroyed=True
                     break
 
-                basis_I.set_bit(sq_sub_top[p], 0)
+                basis_I.set_bit(p, 0)
 
             # then over creators
-            for p in reversed(range(0, nbody)):
-                if (basis_I.get_bit(sq_sub_top[p]) == 1):
+            for p in reversed(sq_creators):
+                if (basis_I.get_bit(p) == 1):
                     destroyed=True
                     break
 
-                basis_I.set_bit(sq_sub_top[p], 1)
+                basis_I.set_bit(p, 1)
 
             if not destroyed:
 
@@ -331,7 +332,7 @@ class SPQE(UCCPQE):
                 qc_temp.apply_operator(sq_op.jw_transform())
                 sign_adjust = qc_temp.get_coeff_vec()[I]
 
-                res_m = coeffs[I] * sign_adjust # * sq_sub_tamp
+                res_m = coeffs[I] * sign_adjust
                 if(np.imag(res_m) > 0.0):
                     raise ValueError("residual has imaginary component, someting went wrong!!")
 
@@ -350,21 +351,18 @@ class SPQE(UCCPQE):
         for mu, m in enumerate(self._tops):
             sq_op = self._pool[m][1]
 
-            temp_idx = sq_op.terms()[0][1][-1]
+            temp_idx = sq_op.terms()[0][2][-1]
             if temp_idx < int(sum(self._ref)/2): # if temp_idx is an occupid idx
-                sq_sub_tamp ,sq_sub_top = sq_op.terms()[0]
+                sq_creators = sq_op.terms()[0][1]
+                sq_annihilators = sq_op.terms()[0][2]
             else:
-                sq_sub_tamp ,sq_sub_top = sq_op.terms()[1]
+                sq_creators = sq_op.terms()[0][2]
+                sq_annihilators = sq_op.terms()[0][1]
 
-            nbody = int(len(sq_sub_top) / 2)
             destroyed = False
             denom = 0.0
 
-            for p, op_idx in enumerate(sq_sub_top):
-                if(p<nbody):
-                    denom -= self._orb_e[op_idx]
-                else:
-                    denom += self._orb_e[op_idx]
+            denom = sum(self._orb_e[x] for x in sq_annihilators) - sum(self._orb_e[x] for x in sq_creators)
 
             res_mu = copy.deepcopy(residuals[mu])
             res_mu /= denom # divide by energy denominator
@@ -611,14 +609,9 @@ class SPQE(UCCPQE):
                     total_parity *= z
 
                 if(total_parity==1):
-                    excitation = particles + holes
-                    dexcitation = list(reversed(excitation))
-                    sigma_I = [1.0, tuple(excitation)]
-                    # need i, j, a, b
-
                     K_temp = qf.SQOperator()
-                    K_temp.add(+1.0, excitation);
-                    K_temp.add(-1.0, dexcitation);
+                    K_temp.add(+1.0, particles, holes);
+                    K_temp.add(-1.0, holes[::-1], particles[::-1]);
                     K_temp.simplify();
                     # this is potentially slow
                     self._pool[I] = [1.0, K_temp]
@@ -685,14 +678,9 @@ class SPQE(UCCPQE):
                     total_parity *= z
 
                 if(total_parity==1):
-                    excitation = particles + holes
-                    dexcitation = list(reversed(excitation))
-                    sigma_I = [1.0, tuple(excitation)]
-                    # need i, j, a, b
-
                     K_temp = qf.SQOperator()
-                    K_temp.add(+1.0, excitation);
-                    K_temp.add(-1.0, dexcitation);
+                    K_temp.add(+1.0, particles + holes);
+                    K_temp.add(-1.0, holes[::-1] + particles[::-1]);
                     K_temp.simplify();
 
                     return K_temp

--- a/tests/jw_transform_test.py
+++ b/tests/jw_transform_test.py
@@ -78,19 +78,59 @@ class JordanWignerTests(unittest.TestCase):
         ]
 
         correct_op = qforte.QuantumOperator()
-        for i in range(len(circ_vec)):
-            correct_op.add(coeff_vec[i], circ_vec[i])
+        for coeff, circ in zip(coeff_vec, circ_vec):
+            correct_op.add(coeff, circ)
 
         # Test qforte construction
         a1 = qforte.SQOperator()
-        a1.add(1.00, [ 2, 3, 4, 6] )
-        a1.add(+1.50, [ 1, 2, 3, 4])
+        a1.add(1.00, [ 2, 3], [4, 6] )
+        a1.add(+1.50, [ 1, 2], [3, 4])
         print(a1.str(), '\n')
         aop = a1.jw_transform()
         print(aop.str(), '\n')
         self.assertTrue(aop.check_op_equivalence(correct_op, True))
 
         #TODO: add more jw test cases
+
+    def test_jw2(self):
+        coeff_vec = [
+            -0.25j,
+            -0.25,
+             0.25,
+            -0.25j,
+            -0.125j,
+             0.125,
+            -0.125,
+            -0.125j,
+            -0.125,
+            -0.125j,
+             0.125j,
+            -0.125
+        ]
+
+        circ_vec = [qforte.build_circuit(x) for x in [
+            "Y_2 X_3",
+            "Y_2 Y_3",
+            "X_2 X_3",
+            "X_2 Y_3",
+            "Z_0 X_1 Y_3 X_4",
+            "Z_0 X_1 Y_3 Y_4",
+            "Z_0 X_1 X_3 X_4",
+            "Z_0 X_1 X_3 Y_4",
+            "Z_0 Y_1 Y_3 X_4",
+            "Z_0 Y_1 Y_3 Y_4",
+            "Z_0 Y_1 X_3 X_4",
+            "Z_0 Y_1 X_3 Y_4"
+            ]]
+        correct_op = qforte.QuantumOperator()
+        for coeff, circ in zip(coeff_vec, circ_vec):
+            correct_op.add(coeff, circ)
+        a = qforte.SQOperator()
+        a.add(1.00, [2, 3], [])
+        a.add(1.00, [1], [3, 4])
+        aop = a.jw_transform()
+        self.assertTrue(aop.check_op_equivalence(correct_op, True))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Description
The primary purpose of this PR is to remove from the SQOperator class (and callers) the assumption that the operators are particle-conserving.

Secondary features of interest: QITE no longer accepts a SQ Hamiltonian argument (which it didn't even use). The PR template is modified from the Forte template to be more relevant for QForte. You can't document new features in the manual if there isn't a manual.

## User Notes
- [x] New Feature: SQ Operators need not be particle conserving
- [x] Major API change! All SQ Operator constructors now require separate lists of creation indices and annihilation indices
- [x] Passing a SQ Hamiltonian to QITE is no longer allowed. This had no effect in previous code.

## Checklist
- [x] Added/updated tests of new features
- [x] Documented source code
- [x] Checked for redundant headers and imports
- [x] Checked for consistency in the formatting of the output file
- [x] Ready to go!
