### PR TITLE
Rename exponentiate_single_term() to exponentiate_pauli_string()

### DIFF
--- a/Tutorials/1-Operators-tutorial .ipynb
+++ b/Tutorials/1-Operators-tutorial .ipynb
@@ -212,7 +212,7 @@
     "The transformation unitary $\\hat{V}^{(\\ell)}_k$ is a one qubit gate that transforms $\\hat{X}$ or $\\hat{Y}$ into $\\hat{Z}$.\n",
     "\n",
     "\n",
-    "In QForte this requires one to pass a coefficient and q `Circuit` to the utility function `exponentiate_single_term().`\n",
+    "In QForte this requires one to pass a coefficient and q `Circuit` to the utility function `exponentiate_pauli_string().`\n",
     "\n",
     "> Build the circuit corresponding to $\\exp(-i 0.5 \\hat{X}_3 \\hat{Z}_2 \\hat{Z}_1 \\hat{Z}_0)$ "
    ]
@@ -250,7 +250,7 @@
     "factor = -1.0j * theta\n",
     "\n",
     "# Construct the unitary for the exonential\n",
-    "Uexp, phase = exponentiate_single_term(factor, circ)\n",
+    "Uexp, phase = exponentiate_pauli_string(factor, circ)\n",
     "print('\\n The exponential unitary circuit: \\n',Uexp)"
    ]
   },

--- a/src/qforte/utils/exponentiate.py
+++ b/src/qforte/utils/exponentiate.py
@@ -5,7 +5,7 @@ Functions for exponentiation of qubit operator terms (circuits)
 import qforte
 import numpy as np
 
-def exponentiate_single_term(coefficient, term, Use_cRz=False, ancilla_idx=None, Use_open_cRz=False):
+def exponentiate_pauli_string(coefficient, term, Use_cRz=False, ancilla_idx=None, Use_open_cRz=False):
     """
     returns the exponential of an string of Pauli operators multiplied by an imaginary coefficient
 
@@ -13,17 +13,16 @@ def exponentiate_single_term(coefficient, term, Use_cRz=False, ancilla_idx=None,
 
     Parameters
     ----------
-    :param coefficient: float
+    :param coefficient: complex
         an imaginary coefficient that multiplies the Pauli string
     :param term: Circuit
         a Pauli string to be exponentiated
     """
     # This function assumes that the factor is imaginary. The following tests for it.
     if np.abs(np.real(coefficient)) > 1.0e-16:
-        print("exp factor: ", coefficient)
-        raise ValueError('exponentiate_single_term() called with a real coefficient')
+        raise ValueError(f'exponentiate_pauli_string() called with a real coefficient {coefficient}')
 
-    # If the Pauli string has no terms this is just a phase factor
+    # If the Pauli string has no terms this is just a phase factor times the identity circuit
     if term.size() == 0:
         return (qforte.Circuit(), np.exp(coefficient))
 

--- a/src/qforte/utils/trotterization.py
+++ b/src/qforte/utils/trotterization.py
@@ -28,7 +28,7 @@ def trotterize(operator, factor=1.0, trotter_number=1, trotter_order=1):
     if (trotter_number == 1) and (trotter_order == 1):
         #loop over terms in operator
         for term in operator.terms():
-            term_generator, phase = qforte.exponentiate_single_term(factor*term[0],term[1])
+            term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1])
             for gate in term_generator.gates():
                 troterized_operator.add(gate)
             total_phase *= phase
@@ -45,7 +45,7 @@ def trotterize(operator, factor=1.0, trotter_number=1, trotter_order=1):
                 ho_op.add( factor * term[0] / float(trotter_number) , term[1])
 
         for trot_term in ho_op.terms():
-            term_generator, phase = qforte.exponentiate_single_term(trot_term[0],trot_term[1])
+            term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1])
             for gate in term_generator.gates():
                 troterized_operator.add(gate)
             total_phase *= phase
@@ -82,13 +82,13 @@ def trotterize_w_cRz(operator, ancilla_qubit_idx, factor=1.0, Use_open_cRz=False
         #loop over terms in operator
         if(Use_open_cRz):
             for term in operator.terms():
-                term_generator, phase = qforte.exponentiate_single_term(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
+                term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
                 for gate in term_generator.gates():
                     troterized_operator.add(gate)
                 total_phase *= phase
         else:
             for term in operator.terms():
-                term_generator, phase = qforte.exponentiate_single_term(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
+                term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
                 for gate in term_generator.gates():
                     troterized_operator.add(gate)
                 total_phase *= phase
@@ -104,13 +104,13 @@ def trotterize_w_cRz(operator, ancilla_qubit_idx, factor=1.0, Use_open_cRz=False
 
         if(Use_open_cRz):
             for trot_term in ho_op.terms():
-                term_generator, phase = qforte.exponentiate_single_term(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
+                term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
                 for gate in term_generator.gates():
                     troterized_operator.add(gate)
                 total_phase *= phase
         else:
             for trot_term in ho_op.terms():
-                term_generator, phase = qforte.exponentiate_single_term(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
+                term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
                 for gate in term_generator.gates():
                     troterized_operator.add(gate)
                 total_phase *= phase


### PR DESCRIPTION
## Description
Implements one of the items from qfortecon Spring 2021 PR #79 that deals with renaming of the function exponentiate_single_term() .

## User Notes
- [x] Changed name of function `exponentiate_single_term()` to `exponentiate_pauli_string()`

## Checklist
- [x] Documented source code
- [x] Ready to go!
