### PR TITLE
Changes UCC class to mixin, fixes minor bugs/importa errors.

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -212,9 +212,10 @@ class AnsatzAlgorithm(Algorithm):
         operators in the pool.
     """
 
-    @abstractmethod
-    def ansatz_circuit(self):
-        pass
+    # TODO: combine mixin class with anstract function definiton 
+    # @abstractmethod
+    # def ansatz_circuit(self):
+    #     raise NotImplementedError("Concrete class must inherit mixin with valid definition of ansatz_circuit().")
 
     # TODO (opt major): write a C function that prepares this super efficiently
     def build_Uvqc(self, amplitudes=None):

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -1,18 +1,19 @@
 """
 Ansatz base classes
 ====================================
-The abstract base classes inheritied by any algorithm that uses a parameterized
-ansatz.
+The mixin classes inheritied by any algorithm that uses a parameterized
+ansatz. Member functions should be minimal and aim only to implement
+the ansatz circut and potential supporting utility functions.
 """
 
 import qforte as qf
-from qforte.abc.algorithm import AnsatzAlgorithm
+# from qforte.abc.algorithm import AnsatzAlgorithm
 
 from qforte.utils.trotterization import trotterize
 
-class UCC(AnsatzAlgorithm):
-    """The abstract base class inheritied by any algorithm that uses a unitary
-    coupled cluster (UCC) inspired ansatz.
+class UCC:
+    """A mixin class for implementing the UCC circuit ansatz, to be inherited by a
+    concrete class UCC+algorithm class.
     """
 
     def ansatz_circuit(self, amplitudes=None):

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -131,8 +131,8 @@ Gate make_gate(std::string type, size_t target, size_t control, std::complex<dou
             std::complex<double> gate[4][4]{
                 {1.0, 0.0, 0.0, 0.0},
                 {0.0, c  ,  s,  0.0},
-                {0.0, s  , -c,  1.0},
-                {0.0, 0.0, 1.0, 0.0},
+                {0.0, s  , -c,  0.0},
+                {0.0, 0.0, 0.0, 1.0},
             };
             return Gate(type, target, control, gate);
         }

--- a/src/qforte/qkd/mrsqk.py
+++ b/src/qforte/qkd/mrsqk.py
@@ -502,12 +502,12 @@ class MRSQK(QSD):
 
         # Adjust dimension of system in case matrix was ill conditioned.
         if(self._ninitial_states > len(self._srqk._eigenvalues)):
-            print('\n', ninitial_states, ' initial states requested, but QK produced ',
+            print('\n', self._ninitial_states, ' initial states requested, but QK produced ',
                         len(self._srqk._eigenvalues), ' stable roots.\n Using ',
                         len(self._srqk._eigenvalues),
                         'intial states instead.')
 
-            self._ninitial_states = len(self._ninitial_states)
+            self._ninitial_states = len(self._srqk._eigenvalues)
 
         sorted_evals_idxs = sorted_largest_idxs(self._srqk._eigenvalues, use_real=True, rev=False)
         sorted_evals = np.zeros((self._ninitial_states), dtype=complex)

--- a/src/qforte/sparse_tensor.cc
+++ b/src/qforte/sparse_tensor.cc
@@ -1,4 +1,4 @@
-
+#include <algorithm>
 #include "sparse_tensor.h"
 
 //// SparseVector


### PR DESCRIPTION
## Description
This PR changes the UCC class to function as a mixin such that it no longer inherits from AnsatzAlgorithm. Additionally this PR 1) fixes a minor bug in MRSQK that occurs with very small hilbert spaces, 2) adds import algorithm in sparse_tensor.cc to comply with gnu compiler errors, and 3) corrects the formulation of the A gate in make_gate.cc.

## User Notes
- [ ] Features added
- [ x ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ x ] Checked for consistency in the formatting of the output file
- [ x ] Ready to go!
