### PR TITLE
Implement UCC-based ansatze as a mixin

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -212,9 +212,8 @@ class AnsatzAlgorithm(Algorithm):
         operators in the pool.
     """
 
-    @abstractmethod
     def ansatz_circuit(self):
-        pass
+        raise NotImplementedError("Concrete class derived from AnsatzAlgorithm must inherit a mixin that defines the ansatz_circuit() member function.")
 
     # TODO (opt major): write a C function that prepares this super efficiently
     def build_Uvqc(self, amplitudes=None):

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -6,11 +6,10 @@ ansatz.
 """
 
 import qforte as qf
-from qforte.abc.algorithm import AnsatzAlgorithm
 
 from qforte.utils.trotterization import trotterize
 
-class UCC(AnsatzAlgorithm):
+class UCC:
     """The abstract base class inheritied by any algorithm that uses a unitary
     coupled cluster (UCC) inspired ansatz.
     """


### PR DESCRIPTION
## Description
This PR implements UCC-based ansatze as a mixin of the `AnsatzAlgorithm` class. The idea is to have the UCC class only define the function `ansatz_circuit(self)`. We also expect change `AnsatzAlgorithm.ansatz_circuit` from abstract to concrete and raise an exception if we call it but no function is defined.

### Why this is as good change?
The class structure in QForte was already using a mixin solution (although it was not explicitly assumed). This PR cleans up the class logic and avoids the diamond-shaped inheritance diagram implied by the previous code (i.e., one class derived from two classes, both derived from the same abstract class).

**Update**: after creating the PR, I realized the changes were already made. This just eliminates comments left from a previous PR.

## User Notes
- [x] Implement UCC as a mixin

## Checklist
- [x] Ready to go!