### PR TITLE
Exact quantum krylov and threshold modifications

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -173,6 +173,7 @@ PYBIND11_MODULE(qforte, m) {
         .def(py::init<>())
         .def("get_element", &SparseMatrix::get_element)
         .def("set_element", &SparseMatrix::set_element)
+        .def("to_vec_map", &SparseMatrix::to_vec_map)
         .def("to_map", &SparseMatrix::to_map);
 
     py::class_<local_timer>(m, "local_timer")

--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -114,6 +114,8 @@ int Circuit::get_num_cnots() const {
     for (const auto& gate : gates_) {
         if(gate.gate_id() == "CNOT" || gate.gate_id() == "cX"){
             n_cnots++;
+        } else if (gate.gate_id() == "A"){
+            n_cnots += 3;
         }
     }
     return n_cnots;

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -269,6 +269,7 @@ class QITE(Algorithm):
         Ipsi_qc = qf.Computer(self._nqb)
         Ipsi_qc.set_coeff_vec(copy.deepcopy(self._qc.get_coeff_vec()))
         # CI[I][J] = (σ_I Ψ)_J
+        self._n_pauli_trm_measures += int(self._NI*(self._NI+1)*0.5)
         CI = np.zeros(shape=(Idim, int(2**self._nqb)), dtype=complex)
 
         for i in range(Idim):

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -126,14 +126,22 @@ Gate make_gate(std::string type, size_t target, size_t control, std::complex<dou
 
     } else {
         if (type == "A") {
+            // std::complex<double> c = std::cos(2.0*parameter);
+            // std::complex<double> s = -onei*std::sin(2.0*parameter);
             std::complex<double> c = std::cos(parameter);
             std::complex<double> s = std::sin(parameter);
             std::complex<double> gate[4][4]{
                 {1.0, 0.0, 0.0, 0.0},
                 {0.0, c  ,  s,  0.0},
-                {0.0, s  , -c,  1.0},
-                {0.0, 0.0, 1.0, 0.0},
+                {0.0, s  , -c,  0.0},
+                {0.0, 0.0, 0.0, 1.0},
             };
+            // std::complex<double> gate[4][4]{
+            //     {1.0, 0.0, 0.0, 0.0},
+            //     {0.0, c  ,  s,  0.0},
+            //     {0.0, s  ,  c,  0.0},
+            //     {0.0, 0.0, 0.0, 1.0},
+            // };
             return Gate(type, target, control, gate);
         }
         if ((type == "cX") or (type == "CNOT")) {

--- a/src/qforte/qkd/__init__.py
+++ b/src/qforte/qkd/__init__.py
@@ -1,2 +1,3 @@
 from .mrsqk import *
 from .srqk import *
+from .nt_srqk import *

--- a/src/qforte/qkd/nt_srqk.py
+++ b/src/qforte/qkd/nt_srqk.py
@@ -1,0 +1,247 @@
+"""
+SRQK classes
+=================================================
+Classes for calculating reference states for quantum
+mechanical systems for the single referece selected
+quantum Krylov algorithm.
+"""
+
+import qforte
+from qforte.abc.qsdabc import QSD
+from qforte.helper.printing import matprint
+from qforte.utils.exp_ops import *
+
+from qforte.maths.eigsolve import canonical_geig_solve
+
+from qforte.utils.state_prep import *
+from qforte.utils.trotterization import (trotterize,
+                                         trotterize_w_cRz)
+
+import numpy as np
+from scipy.linalg import lstsq
+
+class NTSRQK(QSD):
+    """A quantum subspace diagonalization algorithm that generates the many-body
+    basis from different durations of non-Trotterized real time evolution:
+
+    .. math::
+        | \Psi_n \\rangle = e^{-i n \Delta t \hat{H}} | \Phi_0 \\rangle
+
+    In practice Trotterization is used to approximate the time evolution operator.
+
+    Attributes
+    ----------
+
+    _dt : float
+        The time step used in the time evolution unitaries.
+
+    _nstates : int
+        The total number of basis states (s + 1).
+
+    _s : int
+        The greatest m to use in unitaries, equal to the number of time evolutions.
+
+
+    """
+    def run(self,
+            s=3,
+            dt=0.5,
+            target_root=0,
+            diagonalize_each_step=True
+            ):
+
+        self._s = s
+        self._nstates = s+1
+        self._dt = dt
+        self._target_root = target_root
+        self._diagonalize_each_step = diagonalize_each_step
+
+        self._n_classical_params = 0
+        self._n_cnot = 0
+        self._n_pauli_trm_measures = 0
+
+        # Print options banner (should done for all algorithms).
+        self.print_options_banner()
+
+        ######### SRQK #########
+
+        # Build S and H matricies
+        if(self._fast):
+            self._S, self._Hbar = self.build_qk_mats()
+        else:
+            raise ValueError("A realistice implementation of non-Trotterized SRQK is unavalable.")
+
+        # Set the condition number of QSD overlap
+        self._Scond = np.linalg.cond(self._S)
+
+        # Get eigenvalues and eigenvectors
+        self._eigenvalues, self._eigenvectors \
+        = canonical_geig_solve(self._S,
+                               self._Hbar,
+                               print_mats=self._verbose,
+                               sort_ret_vals=True)
+
+        print('\n       ==> QK eigenvalues <==')
+        print('----------------------------------------')
+        for i, val in enumerate(self._eigenvalues):
+            print('  root  {}  {:.8f}    {:.8f}j'.format(i, np.real(val), np.imag(val)))
+
+        # Set ground state energy.
+        self._Egs = np.real(self._eigenvalues[0])
+
+        # Set target state energy.
+        if(self._target_root==0):
+            self._Ets = self._Egs
+        else:
+            self._Ets = np.real(self._eigenvalues[self._target_root])
+
+        ######### SRQK #########
+
+        # Print summary banner (should done for all algorithms).
+        self.print_summary_banner()
+
+        # verify that required attributes were defined
+        # (should be called for all algorithms!)
+        self.verify_run()
+
+    # Define Algorithm abstract methods.
+    def run_realistic(self):
+        raise NotImplementedError('run_realistic() is not fully implemented for NTSRQK.')
+
+    def verify_run(self):
+        self.verify_required_attributes()
+        self.verify_required_QSD_attributes()
+
+    def print_options_banner(self):
+        print('\n-----------------------------------------------------')
+        print('   Non-Trotterized Single Reference Quantum Krylov   ')
+        print('-----------------------------------------------------')
+
+        print('\n\n                   ==> NTQK options <==')
+        print('-----------------------------------------------------------')
+        # General algorithm options.
+        print('Trial reference state:                   ',  ref_string(self._ref, self._nqb))
+        print('Number of Hamiltonian Pauli terms:       ',  self._Nl)
+        print('Trial state preparation method:          ',  self._state_prep_type)
+
+        # Specific SRQK options.
+        print('Dimension of Krylov space (N):           ',  self._nstates)
+        print('Delta t (in a.u.):                       ',  self._dt)
+        print('Target root:                             ',  str(self._target_root))
+
+
+    def print_summary_banner(self):
+        cs_str = '{:.2e}'.format(self._Scond)
+
+        print('\n\n                     ==> QK summary <==')
+        print('-----------------------------------------------------------')
+        print('Condition number of overlap mat k(S):      ', cs_str)
+        print('Final SRQK ground state Energy:           ', round(self._Egs, 10))
+        print('Final SRQK target state Energy:           ', round(self._Ets, 10))
+        print('Number of classical parameters used:       ', self._n_classical_params)
+        print('Number of CNOT gates in deepest circuit:   ', 'N/A')
+        print('Number of Pauli term measurements:         ', self._n_pauli_trm_measures)
+
+    def build_qk_mats(self):
+        """Returns matrices S and H needed for the QK algorithm using the Trotterized
+        form of the unitary operators U_n = exp(-i n dt H)
+
+        The mathematical operations of this function are unphysical for a quantum
+        computer, but efficient for a simulator.
+
+        Returns
+        -------
+        s_mat : ndarray
+            A numpy array containing the elements S_mn = <Phi | Um^dag Un | Phi>.
+            _nstates by _nstates
+
+        h_mat : ndarray
+            A numpy array containing the elements H_mn = <Phi | Um^dag H Un | Phi>
+            _nstates by _nstates
+        """
+
+        h_mat = np.zeros((self._nstates,self._nstates), dtype=complex)
+        s_mat = np.zeros((self._nstates,self._nstates), dtype=complex)
+
+        # Store these vectors for the aid of MRSQK
+        self._omega_lst = []
+        Homega_lst = []
+
+        if(self._diagonalize_each_step):
+            print('\n\n')
+
+            print(f"{'k(S)':>7}{'E(Npar)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}")
+            print('-------------------------------------------------------------------------------')
+
+            if (self._print_summary_file):
+                f = open("summary.dat", "w+", buffering=1)
+                f.write(f"#{'k(S)':>7}{'E(Npar)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}\n")
+                f.write('#-------------------------------------------------------------------------------\n')
+
+
+        Hsp = get_scipy_csc_from_op(self._qb_ham, -1.0j)
+        QC = qforte.Computer(self._nqb)
+        QC.apply_circuit(self._Uprep)
+
+        # get the time evolution vectors
+        psi_t_vecs = apply_time_evolution_op(QC, Hsp, self._dt, self._nstates)
+
+
+        for m in range(self._nstates):
+
+            # # Compute U_m |φ>
+            QC = qforte.Computer(self._nqb)
+            QC.set_coeff_vec(psi_t_vecs[m])
+            self._omega_lst.append(np.asarray(QC.get_coeff_vec(), dtype=complex))
+
+            # Compute H U_m |φ>
+            QC.apply_operator(self._qb_ham)
+            Homega_lst.append(np.asarray(QC.get_coeff_vec(), dtype=complex))
+
+            # Compute S_mn = <φ| U_m^\dagger U_n |φ> and H_mn = <φ| U_m^\dagger H U_n |φ>
+            for n in range(len(self._omega_lst)):
+                h_mat[m][n] = np.vdot(self._omega_lst[m], Homega_lst[n])
+                h_mat[n][m] = np.conj(h_mat[m][n])
+                s_mat[m][n] = np.vdot(self._omega_lst[m], self._omega_lst[n])
+                s_mat[n][m] = np.conj(s_mat[m][n])
+
+            if (self._diagonalize_each_step):
+                # TODO (cleanup): have this print to a separate file
+                k = m+1
+                evals, evecs = canonical_geig_solve(s_mat[0:k, 0:k],
+                                   h_mat[0:k, 0:k],
+                                   print_mats=False,
+                                   sort_ret_vals=True)
+
+                scond = np.linalg.cond(s_mat[0:k, 0:k])
+                self._n_classical_params = k
+                self._n_cnot = 0
+                self._n_pauli_trm_measures  = k * self._Nl
+                self._n_pauli_trm_measures += k * (k-1) * self._Nl
+                self._n_pauli_trm_measures += k * (k-1)
+
+                print(f' {scond:7.2e}    {np.real(evals[self._target_root]):+15.9f}    {self._n_classical_params:8}        {0:10}        {self._n_pauli_trm_measures:12}')
+                if (self._print_summary_file):
+                    f.write(f'  {scond:7.2e}    {np.real(evals[self._target_root]):+15.9f}    {self._n_classical_params:8}        {0:10}        {self._n_pauli_trm_measures:12}\n')
+
+        if (self._diagonalize_each_step and self._print_summary_file):
+            f.close()
+
+        self._n_classical_params = self._nstates
+        self._n_cnot = 0
+        # diagonal terms of Hbar
+        self._n_pauli_trm_measures  = self._nstates * self._Nl
+        # off-diagonal of Hbar (<X> and <Y> of Hadamard test)
+        self._n_pauli_trm_measures += self._nstates*(self._nstates-1) * self._Nl
+        # off-diagonal of S (<X> and <Y> of Hadamard test)
+        self._n_pauli_trm_measures += self._nstates*(self._nstates-1)
+
+
+        return s_mat, h_mat
+
+    def build_qk_mats_realistic(self):
+        pass
+
+    #TODO depricate this function
+    def matrix_element(self, m, n, use_op=False):
+        pass

--- a/src/qforte/qubit_operator.cc
+++ b/src/qforte/qubit_operator.cc
@@ -92,7 +92,7 @@ void QubitOperator::simplify(bool combine_like_terms) {
     terms_.clear();
     if(combine_like_terms){
         for (const auto &uniqe_trm : uniqe_trms){
-            if (std::abs(uniqe_trm.second) > 1.0e-16) {
+            if (std::abs(uniqe_trm.second) > 1.0e-12) {
                 terms_.push_back(std::make_pair(uniqe_trm.second, uniqe_trm.first));
             }
         }

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -249,13 +249,15 @@ void SQOpPool::fill_pool(std::string pool_type){
                 }
             }
         }
-    } else if ( (pool_type=="SD") || (pool_type=="SDT") || (pool_type=="SDTQ") || (pool_type=="SDTQP") || (pool_type=="SDTQPH") ) {
+    } else if ( (pool_type=="S") || (pool_type=="SD") || (pool_type=="SDT") || (pool_type=="SDTQ") || (pool_type=="SDTQP") || (pool_type=="SDTQPH") ) {
 
         int max_nbody = 0;
 
-        if(pool_type=="SD") {
+        if(pool_type=="S") {
+            max_nbody = 1;
+        } else if(pool_type=="SD") {
             max_nbody = 2;
-        } else if(pool_type=="SDT") {
+        }else if(pool_type=="SDT") {
             max_nbody = 3;
         } else if(pool_type=="SDTQ") {
             max_nbody = 4;

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -78,7 +78,7 @@ void SQOperator::simplify() {
     }
     terms_.clear();
     for (const auto &unique_term : unique_terms){
-        if (std::abs(unique_term.second) > 1.0e-16){
+        if (std::abs(unique_term.second) > 1.0e-12){
             terms_.push_back(std::make_tuple(unique_term.second, unique_term.first.first, unique_term.first.second));
         }
     }

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -103,6 +103,8 @@ class UCCNPQE(UCCPQE):
             if(np.abs(tmu) > 1.0e-12):
                 self._n_nonzero_params += 1
 
+        self._n_pauli_trm_measures = int(2*self._Nl*self._res_vec_evals*self._n_nonzero_params + self._Nl*self._res_vec_evals)
+
         self.print_summary_banner()
         self.verify_run()
 

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -187,8 +187,13 @@ class UCCNVQE(UCCVQE):
                                     callback=self.report_iteration)
 
             # account for paulit term measurement for gradient evaluations
-            for m in range(len(self._tamps)):
-                self._n_pauli_trm_measures += self._Nm[m] * self._Nl * res.njev
+            # for m in range(len(self._tamps)):
+            #     self._n_pauli_trm_measures += self._Nm[m] * self._Nl * res.njev
+
+            for tmu in res.x:
+                if(np.abs(tmu) > 1.0e-12):
+                    self._n_pauli_trm_measures += int(2 * self._Nl * res.njev)
+
 
         else:
             print('  \n--> Begin opt with grad estimated using first-differences:')
@@ -197,6 +202,9 @@ class UCCNVQE(UCCVQE):
                                     method=self._optimizer,
                                     options=opts,
                                     callback=self.report_iteration)
+
+            # account for pauli term measurement for energy evaluations
+            self._n_pauli_trm_measures += self._Nl * res.nfev
 
         if(res.success):
             print('  => Minimization successful!')
@@ -221,9 +229,6 @@ class UCCNVQE(UCCVQE):
 
         self._n_classical_params = len(self._tamps)
         self._n_cnot = self.build_Uvqc().get_num_cnots()
-
-        # account for pauli term measurement for energy evaluations
-        self._n_pauli_trm_measures += self._Nl * res.nfev
 
 
     def initialize_ansatz(self):

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -194,6 +194,8 @@ class UCCNVQE(UCCVQE):
                 if(np.abs(tmu) > 1.0e-12):
                     self._n_pauli_trm_measures += int(2 * self._Nl * res.njev)
 
+            self._n_pauli_trm_measures += int(self._Nl * res.nfev)
+
 
         else:
             print('  \n--> Begin opt with grad estimated using first-differences:')

--- a/src/qforte/utils/__init__.py
+++ b/src/qforte/utils/__init__.py
@@ -4,3 +4,4 @@ from .transforms import *
 from .qft import *
 from .state_prep import *
 from .op_pools import *
+from .exp_ops import *

--- a/src/qforte/utils/exp_ops.py
+++ b/src/qforte/utils/exp_ops.py
@@ -1,0 +1,34 @@
+"""
+Utility functions for handeling exponentials of QubitOperators
+"""
+
+import qforte
+import numpy as np
+
+from scipy.sparse import csc_matrix
+from scipy.sparse.linalg import expm, expm_multiply
+
+def get_scipy_csc_from_op(Hop, factor):
+
+    nqubits = Hop.num_qubits()
+    nbasis = 2 ** nqubits
+    sp_mat = Hop.sparse_matrix(nqubits)
+
+    Ivals = []
+    Jvals = []
+    data = []
+
+    for I in sp_mat.to_vec_map():
+        for J in sp_mat.to_vec_map()[I].to_map():
+            Ivals.append(I)
+            Jvals.append(J)
+            data.append(factor * sp_mat.to_vec_map()[I].to_map()[J])
+
+    return csc_matrix((data, (Ivals, Jvals)), shape=(nbasis, nbasis), dtype=complex)
+
+
+def apply_time_evolution_op(qc, Hcsc, tn, nstates):
+
+    qc_vec = np.array(qc.get_coeff_vec())
+
+    return expm_multiply(Hcsc, qc_vec, start=0.0, stop=tn, num=nstates, endpoint=True)

--- a/src/qforte/utils/exponentiate.py
+++ b/src/qforte/utils/exponentiate.py
@@ -19,7 +19,7 @@ def exponentiate_pauli_string(coefficient, term, Use_cRz=False, ancilla_idx=None
         a Pauli string to be exponentiated
     """
     # This function assumes that the factor is imaginary. The following tests for it.
-    if np.abs(np.real(coefficient)) > 1.0e-16:
+    if np.abs(np.real(coefficient)) > 1.0e-14:
         raise ValueError(f'exponentiate_pauli_string() called with a real coefficient {coefficient}')
 
     # If the Pauli string has no terms this is just a phase factor times the identity circuit

--- a/tests/circ_ref_test.py
+++ b/tests/circ_ref_test.py
@@ -28,7 +28,6 @@ class CircuitReferenceTest(unittest.TestCase):
                              build_type = 'psi4',
                              basis='sto-3g',
                              mol_geometry = geom)
-                             # filename=data_path)
 
 
         alg = UCCNVQE(mol)
@@ -40,7 +39,7 @@ class CircuitReferenceTest(unittest.TestCase):
         alg2.run(dt=1.0, s=12)
 
         Egs = alg2.get_gs_energy()
-        self.assertLess(abs(Egs-Efci), 1.0e-6)
+        self.assertLess(abs(Egs-Efci), 5.0e-6)
 
 
 

--- a/tests/fast_qk_test.py
+++ b/tests/fast_qk_test.py
@@ -2,7 +2,9 @@ import unittest
 from qforte import qforte
 from qforte.qkd.mrsqk import MRSQK
 from qforte.qkd.srqk import SRQK
+from qforte.qkd.nt_srqk import NTSRQK
 from qforte.system.molecular_info import Molecule
+import numpy as np
 
 class QKDTests(unittest.TestCase):
     def test_H4_fast_qkd(self):
@@ -395,17 +397,23 @@ class QKDTests(unittest.TestCase):
         mol = Molecule()
         mol.set_hamiltonian(H4_qubit_hamiltonian)
 
-        MRSQK
+        # MRSQK
         alg2 = MRSQK(mol, reference=ref, trotter_number=100)
         alg2.run(s=3, d=3)
         Egs2 = alg2.get_gs_energy()
         self.assertLess(abs(Egs2-E_fci), 1.0e-6)
 
-        SRQK
+        # SRQK
         alg1 = SRQK(mol, reference=ref, trotter_number=100)
         alg1.run(s=6)
         Egs1 = alg1.get_gs_energy()
         self.assertLess(abs(Egs1-E_fci), 1.0e-4)
+
+        # Non-Trotteized (exact) SRQK
+        alg0 = NTSRQK(mol, reference=ref)
+        alg0.run(s=6, dt = 0.8)
+        Egs0 = alg0.get_gs_energy()
+        self.assertLess(abs(Egs0-E_fci), 1.0e-4)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description
This PR adds the ability to use the SparseMatrix class to perform single-reference quantum krylov without trotterization. Additionally, it slightly modifies thresholds i) for operator simplification (in the combining of like terms), and (ii) for the exponentiation of Pauli terms with imaginary coefficients. Finally, this PR modifies the way in which various algorithms count the total number of Pauli-string (term) evaluations to be consistent with the most recent literature.   

## User Notes
- [ x ] Features added
- [ x ] Changes to compilation (if any)

## Checklist
- [ x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ x ] Documented source code
- [ x ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ x ] Ready to go!
