### PR TITLE
Removed unused argument

### DIFF
--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -336,7 +336,6 @@ class ADAPTVQE(UCCVQE):
         if self._use_commutator_grad_selection:
             grads = self.measure_operators(self._commutator_pool, Uvqc)
         else:
-            # grads = self.measure_gradient(use_entire_pool=True)
             grads = self.measure_gradient3()
 
         for m, grad_m in enumerate(grads):

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -164,7 +164,7 @@ class UCCNPQE(UCCPQE):
         by using a quasi-Newton uptate procedure for the amplutudes paired with
         the direct inversion of iterative subspace (DIIS) convergece acceleration.
         """
-        # draws heavy insiration from Daniel Smith's ccsd_diss.py code in psi4 numpy
+        # draws heavy inspiration from Daniel Smith's ccsd_diss.py code in psi4 numpy
         diis_dim = 0
         t_diis = [copy.deepcopy(self._tamps)]
         e_diis = []


### PR DESCRIPTION
## Description

The next step of refactoring. As the comment says, the `use_entire_pool` argument of `measure_gradient` was always set to False - no code ever changed from the default. The argument is now eliminated from the code.

## User Notes
- [x] Eliminated `use_entire_pool` argument of `measure_gradient`

## Checklist
- [x] Ready to go!
