### PR TITLE
One hopefully last bit of pre-DIIS refactoring

### DIFF
--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -62,3 +62,37 @@ class UCC:
 
             print(f'  {i:3}     {ei:+16.12f}')
             self._orb_e.append(ei)
+
+    def get_res_over_mpdenom(self, residuals):
+        """This function returns a vector given by the residuals dividied by the
+        respective Moller Plesset denominators.
+
+        Parameters
+        ----------
+        residuals : list of floats
+            The list of (real) floating point numbers which represent the
+            residuals.
+        """
+
+        resids_over_denoms = []
+
+        # each operator needs a score, so loop over toperators
+        for mu, m in enumerate(self._tops):
+            sq_op = self._pool[m][1]
+
+            temp_idx = sq_op.terms()[0][2][-1]
+            if temp_idx < int(sum(self._ref)/2): # if temp_idx is an occupid idx
+                sq_creators = sq_op.terms()[0][1]
+                sq_annihilators = sq_op.terms()[0][2]
+            else:
+                sq_creators = sq_op.terms()[0][2]
+                sq_annihilators = sq_op.terms()[0][1]
+
+            denom = sum(self._orb_e[x] for x in sq_annihilators) - sum(self._orb_e[x] for x in sq_creators)
+
+            res_mu = residuals[mu] / denom
+
+            resids_over_denoms.append(res_mu)
+
+        return resids_over_denoms
+

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -70,36 +70,3 @@ class UCCPQE(PQE, UCC):
     #TODO: consider moving functions from uccnpqe or spqe into this class to
     #      to prevent duplication of code
 
-    def get_res_over_mpdenom(self, residuals):
-        """This function returns a vector given by the residuals dividied by the
-        respective Moller Plesset denominators.
-
-        Parameters
-        ----------
-        residuals : list of floats
-            The list of (real) floating point numbers which represent the
-            residuals.
-        """
-
-        resids_over_denoms = []
-
-        # each operator needs a score, so loop over toperators
-        for mu, m in enumerate(self._tops):
-            sq_op = self._pool[m][1]
-
-            temp_idx = sq_op.terms()[0][2][-1]
-            if temp_idx < int(sum(self._ref)/2): # if temp_idx is an occupid idx
-                sq_creators = sq_op.terms()[0][1]
-                sq_annihilators = sq_op.terms()[0][2]
-            else:
-                sq_creators = sq_op.terms()[0][2]
-                sq_annihilators = sq_op.terms()[0][1]
-
-            denom = sum(self._orb_e[x] for x in sq_annihilators) - sum(self._orb_e[x] for x in sq_creators)
-
-            res_mu = residuals[mu] / denom
-
-            resids_over_denoms.append(res_mu)
-
-        return resids_over_denoms
-

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -210,24 +210,16 @@ class UCCNVQE(UCCVQE):
 
         if(res.success):
             print('  => Minimization successful!')
-            print(f'  => Minimum Energy: {res.fun:+12.10f}')
-            self._Egs = res.fun
-            if(self._optimizer == 'POWELL'):
-                print(type(res.fun))
-                print(res.fun)
-                self._Egs = res.fun[()]
-            self._final_result = res
-            self._tamps = list(res.x)
         else:
             print('  => WARNING: minimization result may not be tightly converged.')
-            print(f'  => Minimum Energy: {res.fun:+12.10f}')
-            self._Egs = res.fun
-            if(self._optimizer == 'POWELL'):
-                print(type(res.fun))
-                print(res.fun)
-                self._Egs = res.fun[()]
-            self._final_result = res
-            self._tamps = list(res.x)
+        print(f'  => Minimum Energy: {res.fun:+12.10f}')
+        self._Egs = res.fun
+        if(self._optimizer == 'POWELL'):
+            print(type(res.fun))
+            print(res.fun)
+            self._Egs = res.fun[()]
+        self._final_result = res
+        self._tamps = list(res.x)
 
         self._n_classical_params = len(self._tamps)
         self._n_cnot = self.build_Uvqc().get_num_cnots()


### PR DESCRIPTION
## Description
This PR moves removes some code duplication and also moves the ability to take MP denominators off of PQE and onto the general AnsatzAlgorithm, right by the ability to compute orbital energies. I also did some minor code cleanup in `uccnvqe.py`.

I expect that the next PR will be the one that lets VQE optimize with DIIS. This will be the largest of the PRs I've submitted in the last day or two, but I don't see a good way to break it down any further.

## User Notes
- [x] Generalized `get_res_over_mpdenom` out of PQE 

## Checklist
- [x] Ready to go!
