### PR TITLE
Rename diis_maxiter

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -196,6 +196,9 @@ class AnsatzAlgorithm(Algorithm):
     _Nm: list of int
         Number of circuits for each operator in the pool.
 
+    _opt_maxiter : int
+        The maximum number of iterations for the classical optimizer.
+
     _pool : list of tuple(complex, SqOperator)
         The linear combination of (optionally symmetrized) single and double
         excitation operators to consider. This is represented as a list.

--- a/src/qforte/abc/pqeabc.py
+++ b/src/qforte/abc/pqeabc.py
@@ -27,8 +27,7 @@ class PQE(AnsatzAlgorithm):
             raise NotImplementedError('Concrete PQE class must define self._converged attribute.')
 
         if not hasattr(self, '_opt_maxiter'):
-            if not hasattr(self, '_diis_maxiter'):
-                raise NotImplementedError('Concrete PQE class must define self._diis_maxiter OR self._opt_maxiter attribute.')
+            raise NotImplementedError('Concrete PQE class must define self._opt_maxiter attribute.')
 
         if not hasattr(self, '_opt_thresh'):
             if not hasattr(self, '_res_vec_thresh'):

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -41,9 +41,6 @@ class UCCPQE(PQE, UCC):
         values may be sampled from. Is zero by default such that all residuals
         are exact.
 
-    _diis_maxiter : int
-        The maximum number of DIIS iteratios to perform.
-
     _res_vec_thresh : float
         The numberical threshold for the norm of the residual vector, used to
         determine when PQE has converged.
@@ -62,10 +59,10 @@ class UCCPQE(PQE, UCC):
     def verify_required_UCCPQE_attributes(self):
 
         if not hasattr(self, '_pool_type'):
-            raise NotImplementedError('Concrete UCCVQE class must define self._pool_type attribute.')
+            raise NotImplementedError('Concrete UCCPQE class must define self._pool_type attribute.')
 
         if not hasattr(self, '_pool_obj'):
-            raise NotImplementedError('Concrete UCCVQE class must define self._pool_obj attribute.')
+            raise NotImplementedError('Concrete UCCPQE class must define self._pool_obj attribute.')
 
     #TODO: consider moving functions from uccnpqe or spqe into this class to
     #      to prevent duplication of code

--- a/src/qforte/abc/vqeabc.py
+++ b/src/qforte/abc/vqeabc.py
@@ -18,7 +18,7 @@ class VQE(AnsatzAlgorithm):
 
     Attributes
     ----------
-    _ompimizer : string
+    _optimizer : string
         The type of optimizer to use for the classical portion of VQE. Suggested
         algorithms are 'BFGS' or 'Nelder-Mead' although there are many options
         (see SciPy.optimize.minimize documentation).
@@ -29,9 +29,6 @@ class VQE(AnsatzAlgorithm):
     _final_result : object
         The result object returned by the scipy optimizer at the end of the
         optimization.
-
-    _opt_maxiter : int
-        The maximum number of iterations for the classical optimizer.
 
     _opt_thresh : float
         The numerical convergence threshold for the specified classical

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -54,7 +54,7 @@ class SPQE(UCCPQE):
             dt=0.001,
             M_omega = 'inf',
             res_vec_thresh = 1.0e-5,
-            diis_maxiter = 30,
+            opt_maxiter = 30,
             use_cumulative_thresh=True):
 
         if(self._state_prep_type != 'occupation_list'):
@@ -70,7 +70,7 @@ class SPQE(UCCPQE):
 
         self._use_cumulative_thresh = use_cumulative_thresh
         self._res_vec_thresh = res_vec_thresh
-        self._diis_maxiter = diis_maxiter
+        self._opt_maxiter = opt_maxiter
 
         self._nbody_counts = []
         self._n_classical_params_lst = []
@@ -200,7 +200,7 @@ class SPQE(UCCPQE):
 
         opt_thrsh_str = '{:.2e}'.format(self._res_vec_thresh)
         spqe_thrsh_str = '{:.2e}'.format(self._spqe_thresh)
-        print('DIIS maxiter:                            ',  self._diis_maxiter)
+        print('DIIS maxiter:                            ',  self._opt_maxiter)
         print('DIIS residual-norm threshold (omega_r):  ',  opt_thrsh_str)
         print('Operator pool type:                      ',  'full')
         print('SPQE residual-norm threshold (Omega):    ',  spqe_thrsh_str)
@@ -234,7 +234,7 @@ class SPQE(UCCPQE):
         print('\n    k iteration         Energy               dE           Nrvec ev      Nrm ev*         ||r||')
         print('---------------------------------------------------------------------------------------------------')
 
-        for k in range(1, self._diis_maxiter+1):
+        for k in range(1, self._opt_maxiter+1):
             t_old = copy.deepcopy(self._tamps)
 
             #do regular update

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -135,7 +135,7 @@ class UCCNPQE(UCCPQE):
             print('Measurement varience thresh:             ',  0.01)
 
         res_thrsh_str = '{:.2e}'.format(self._res_vec_thresh)
-        print('DIIS maxiter:                            ',  self._opt_maxiter) # RENAME
+        print('DIIS maxiter:                            ',  self._opt_maxiter)
         print('DIIS res-norm threshold:                 ',  res_thrsh_str)
 
         print('Operator pool type:                      ',  str(self._pool_type))

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -49,7 +49,7 @@ class UCCNPQE(UCCPQE):
     def run(self,
             pool_type='SD',
             res_vec_thresh = 1.0e-5,
-            diis_maxiter = 40,
+            opt_maxiter = 40,
             noise_factor = 0.0):
 
         if(self._state_prep_type != 'occupation_list'):
@@ -57,7 +57,7 @@ class UCCNPQE(UCCPQE):
 
         self._pool_type = pool_type
         self._res_vec_thresh = res_vec_thresh
-        self._diis_maxiter = diis_maxiter
+        self._opt_maxiter = opt_maxiter
         self._noise_factor = noise_factor
 
         self._tops = []
@@ -135,7 +135,7 @@ class UCCNPQE(UCCPQE):
             print('Measurement varience thresh:             ',  0.01)
 
         res_thrsh_str = '{:.2e}'.format(self._res_vec_thresh)
-        print('DIIS maxiter:                            ',  self._diis_maxiter) # RENAME
+        print('DIIS maxiter:                            ',  self._opt_maxiter) # RENAME
         print('DIIS res-norm threshold:                 ',  res_thrsh_str)
 
         print('Operator pool type:                      ',  str(self._pool_type))
@@ -180,7 +180,7 @@ class UCCNPQE(UCCPQE):
             f.write('\n#--------------------------------------------------------------------------------------------------')
             f.close()
 
-        for k in range(1, self._diis_maxiter+1):
+        for k in range(1, self._opt_maxiter+1):
 
             t_old = copy.deepcopy(self._tamps)
 


### PR DESCRIPTION
## Description
Unfortunately, I need more cleanup PRs before I can make DIIS VQE happen. This one renames a variable to match the name the VQE code uses. This one should be light, and the next one more intense.

## User Notes
- [x] `diis_maxiter` -> `opt_maxiter`

## Checklist
- [x] Ready to go!
