### PR TITLE
Remove `_nel`

### DIFF
--- a/src/qforte/system/molecular_info.py
+++ b/src/qforte/system/molecular_info.py
@@ -95,9 +95,6 @@ class Molecule(object):
     def set_sq_of_ham(self, sq_of_ham):
         self._sq_of_ham = sq_of_ham
 
-    def set_nel(self, nel):
-        self._nel = nel
-
     def set_hf_reference(self, hf_reference):
         self._hf_reference = hf_reference
 


### PR DESCRIPTION
## Description
This PR removes the `set_nel` function, which set `_nel`. We can re-add it if we need it. Right now, the attribute is used literally nowhere in the code.

## User Notes
- [x] Removed `set_nel`

## Checklist
- [x] Ready to go!
