### PR TITLE
Move Responsibility for Setting Gradient Measurement Metadata

### DIFF
--- a/src/qforte/maths/optimizer.py
+++ b/src/qforte/maths/optimizer.py
@@ -39,9 +39,6 @@ def diis_solve(self, residual):
         dE = Ek - Ek0
         Ek0 = Ek
 
-        self._res_vec_evals += 1
-        self._res_m_evals += len(self._tamps)
-
         print(f'     {k:7}        {Ek:+12.10f}      {dE:+12.10f}      {self._res_vec_evals:4}        {self._res_m_evals:6}       {rk_norm:+12.10f}')
 
         if (self._print_summary_file):

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -256,6 +256,9 @@ class UCCNPQE(UCCPQE):
 
             residuals.append(res_m)
 
+        self._res_vec_evals += 1
+        self._res_m_evals += len(self._tamps)
+
         return residuals
 
     def initialize_ansatz(self):


### PR DESCRIPTION
## Description
Closes #114. The responsibility for tracking the number of gradient measurements is moved out of the DIIS code and into the calling code's residual function. This prevents double-counting in PQE and guarantees the variables are set properly.

## Checklist
- [x] Ready to go!
