### PR TITLE
TFIM Adapter

### DIFF
--- a/src/qforte/adapters/model_adapters.py
+++ b/src/qforte/adapters/model_adapters.py
@@ -1,0 +1,20 @@
+import qforte as qf
+from qforte.system.molecular_info import System
+
+def create_TFIM(n: int, h: float, J: float, closed = False):
+    """Creates a Transverse Field Ising Model hamiltonian with
+    open boundary conditions, i.e., no interaction between the
+    first and last spin sites."""
+
+    TFIM = System()
+    TFIM.hamiltonian = qf.QubitOperator()
+
+    circuit = [(-h, f"Z_{i}") for i in range(n)]
+    circuit += [(-J, f"X_{i} X_{i+1}") for i in range(n-1)]
+
+    for coeff, op_str in circuit:
+        TFIM.hamiltonian.add(coeff, qf.build_circuit(op_str))
+
+    TFIM.hf_reference = [0] * n
+
+    return TFIM

--- a/src/qforte/adapters/model_adapters.py
+++ b/src/qforte/adapters/model_adapters.py
@@ -1,10 +1,20 @@
 import qforte as qf
 from qforte.system.molecular_info import System
 
-def create_TFIM(n: int, h: float, J: float, closed = False):
-    """Creates a Transverse Field Ising Model hamiltonian with
+def create_TFIM(n: int, h: float, J: float):
+    """Creates a 1D Transverse Field Ising Model hamiltonian with
     open boundary conditions, i.e., no interaction between the
-    first and last spin sites."""
+    first and last spin sites.
+
+    n: int
+        Number of lattice sites
+
+    h: float
+        Strength of magnetic field
+
+    j: float
+        Interaction strength 
+    """
 
     TFIM = System()
     TFIM.hamiltonian = qf.QubitOperator()

--- a/src/qforte/system/system_factory.py
+++ b/src/qforte/system/system_factory.py
@@ -1,4 +1,5 @@
 from qforte.adapters import molecule_adapters as MA
+from qforte.adapters import model_adapters as mod
 
 def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwargs):
 
@@ -21,24 +22,33 @@ def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwarg
 
     """
 
-    kwargs.setdefault('basis', 'sto-3g')
-    kwargs.setdefault('multiplicity', 1)
-    kwargs.setdefault('charge', 0)
-    kwargs.setdefault('description', "")
-    kwargs.setdefault('filename', "")
-    kwargs.setdefault('hdf5_dir', None)
 
-    adapters = {
+    molecule_adapters = {
         "openfermion": MA.create_openfermion_mol,
         "external": MA.create_external_mol,
         "psi4": MA.create_psi_mol
     }
 
+    model_adapters = {
+        "TFIM": mod.create_TFIM
+    }
+
     if (system_type=='molecule'):
+        kwargs.setdefault('basis', 'sto-3g')
+        kwargs.setdefault('multiplicity', 1)
+        kwargs.setdefault('charge', 0)
+        kwargs.setdefault('description', "")
+        kwargs.setdefault('filename', "")
+        kwargs.setdefault('hdf5_dir', None)
         try:
-            adapter = adapters[build_type]
+            adapter = molecule_adapters[build_type]
         except:
-            raise TypeError(f"build type {build_type} not supported, supported types are: " + ", ".join(adapters.keys()))
+            raise TypeError(f"build type {build_type} not supported, supported types are: " + ", ".join(molecule_adapters.keys()))
+    elif (system_type=='model'):
+        try:
+            adapter = model_adapters[build_type]
+        except:
+            raise TypeError(f"build type {build_type} not supported, supported types are: " + ", ".join(model_adapters.keys()))
 
     else:
         raise TypeError("system type not supported, supported type is 'molecule'.")

--- a/src/qforte/system/system_factory.py
+++ b/src/qforte/system/system_factory.py
@@ -51,6 +51,6 @@ def system_factory(system_type = 'molecule', build_type = 'openfermion', **kwarg
             raise TypeError(f"build type {build_type} not supported, supported types are: " + ", ".join(model_adapters.keys()))
 
     else:
-        raise TypeError("system type not supported, supported type is 'molecule'.")
+        raise TypeError("system type not supported, supported types are 'molecule' and 'model'.")
 
     return adapter(**kwargs)


### PR DESCRIPTION
## Description
This PR adds an adapter to produce a transverse field Ising model Hamiltonian. _Unfortunately_, I can't test it effectively, because all of our electronic structure algorithms are used to thinking that the ground state |0000> means no electrons to excite, rather than "everything is in the beta state". Consequently, I'm not sure how to test this one until I get the operator pools in a more functional state.

Let me know if more documentation is needed, as well. QForte documentation is meager as it is.

## User Notes
- [x] TFIM added

## Checklist
- [x] Ready to go?
