### PR TITLE
Add copy constructor for Gate

### DIFF
--- a/src/qforte/gate.h
+++ b/src/qforte/gate.h
@@ -27,6 +27,8 @@ class Gate {
     Gate(const std::string& label, size_t target, size_t control,
                 std::complex<double> gate[4][4]);
 
+    Gate(const Gate& gate) = default;
+
     /// Return the target qubit
     size_t target() const;
 


### PR DESCRIPTION
## Description
Fixes a bug found by @imagoulas, but I'd like a review from @fevangelista, because this requires some C++ knowledge.

This PR adds a _copy constructor_ for the gate class. The implicitly defined copy constructor that C++ provides was not copying the `label`, which led to wrong printout.

## User Notes
- [x] Fixed a bug where labels for `Gate` objects could be lost

## Checklist
- [ ] Do I need a test for this one?
- [x] Ready to go!
