### PR TITLE
Support custom operator pools

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -214,7 +214,7 @@ class AnsatzAlgorithm(Algorithm):
         excitation operators to consider. This is represented as a list.
         Each entry is a pair of a complex coefficient and an SqOperator object.
 
-    _pool_obj : SqOpPool
+    _pool_obj : SQOpPool
         A pool of second quantized operators we use in the ansatz.
 
     _tops : list
@@ -249,11 +249,12 @@ class AnsatzAlgorithm(Algorithm):
         """ This function populates an operator pool with SQOperator objects.
         """
 
-        self._pool_obj = qf.SQOpPool()
-        self._pool_obj.set_orb_spaces(self._ref)
-
         if self._pool_type in {'sa_SD', 'GSD', 'SD', 'SDT', 'SDTQ', 'SDTQP', 'SDTQPH'}:
+            self._pool_obj = qf.SQOpPool()
+            self._pool_obj.set_orb_spaces(self._ref)
             self._pool_obj.fill_pool(self._pool_type)
+        elif isinstance(self._pool_type, qf.SQOpPool):
+            self._pool_obj = self._pool_type
         else:
             raise ValueError('Invalid operator pool type specified.')
 

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -47,6 +47,7 @@ class UCCVQE(VQE, UCC):
             SDTQ: At most four orbital excitations.
             SDTQP: At most five orbital excitations.
             SDTQPH: At most six orbital excitations.
+            GSD: At most two excitations, from any orbital to any orbital.
 
     _prev_energy : float
         The energy from the previous iteration.

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -36,9 +36,10 @@ class UCCVQE(VQE, UCC):
     Attributes
     ----------
 
-    _pool_type : string
+    _pool_type : string or SQOpPool
         Specifies the kinds of tamplitudes allowed in the UCCN-VQE
-        parameterization.
+        parameterization. If an SQOpPool is supplied, that is used as the
+        operator pool. The following strings are allowed:
             SA_SD: At most two orbital excitations. Assumes a singlet wavefunction and closed-shell Slater determinant
                    reducing the number of amplitudes.
             SD: At most two orbital excitations.

--- a/tests/custom_pool_test.py
+++ b/tests/custom_pool_test.py
@@ -1,0 +1,33 @@
+import unittest
+import qforte as qf
+from qforte.ucc.uccnvqe import UCCNVQE
+from qforte.system import system_factory
+
+class CustomPoolTests(unittest.TestCase):
+
+    def test_vqe(self):
+        print('\n')
+        Efci = -1.108873060057971
+
+        mol = system_factory(system_type = 'molecule',
+                                     build_type = 'psi4',
+                                     basis='sto-6g',
+                                     mol_geometry = [('H', (0, 0, 0)),
+                                                     ('H', (0, 0, 1))],
+                                     symmetry = "c2v")
+
+        pool = qf.SQOpPool()
+        sq_op = qf.SQOperator()
+        sq_op.add_term( 1, [0, 1], [2, 3]) 
+        sq_op.add_term(-1, [2, 3], [0, 1]) 
+        pool.add_term(1, sq_op)
+
+        alg = UCCNVQE(mol)
+        alg.run(pool_type = pool,
+                use_analytic_grad = True)
+
+        self.assertAlmostEqual(alg.get_gs_energy(), Efci, 10)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Description
This PR adds support for users passing their own operator pools. I'll want to allow QubitOpPools soon, but this is a start.

## User Notes
- [x] Users can add their own operator pools! 

## Checklist
- [x] Added/updated tests of new features
- [x] Ready to go!
