### PR TITLE
Fix PSIO Error

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -351,6 +351,9 @@ def create_psi_mol(**kwargs):
     qforte_mol.sq_hamiltonian = Hsq
     qforte_mol.hamiltonian = Hsq.jw_transform()
 
+    # Order Psi4 to delete its temporary files.
+    psi4.core.clean()
+    
     return qforte_mol
 
 


### PR DESCRIPTION
## Description
Prevents temporary files from one Psi computation from interfering with the files from another computation. On my computer, this is enough to prevent the bug reported by Ilias, where there is a PSIO error involving `incorrect block end address`.

## Checklist
- [x] Ready to go!
