### PR TITLE
Added printing statements in tests for debugging

### DIFF
--- a/tests/adapt_vqe_test.py
+++ b/tests/adapt_vqe_test.py
@@ -11,7 +11,7 @@ data_path = os.path.join(THIS_DIR, 'H4-sto6g-075a.json')
 
 class ADAPTVQETests(unittest.TestCase):
     def test_H4_adapt_vqe_exact(self):
-        print('\n')
+        print('\nSTART test_H4_adapt_vqe_exact\n')
 
         # The FCI energy for H4 at 0.75 Angstrom in a sto-6g basis
         Efci = -2.1628978832666865

--- a/tests/advanced_gates_test.py
+++ b/tests/advanced_gates_test.py
@@ -3,7 +3,7 @@ from qforte import *
 
 class AdvGateTests(unittest.TestCase):
     def test_advanced_gates(self):
-        print('\n')
+        print('\nSTART test_advanced_gates\n')
         trial_state = Computer(4)
         trial_circ = build_circuit('X_0 X_1')
         trial_state.apply_circuit(trial_circ)

--- a/tests/basis.py
+++ b/tests/basis.py
@@ -3,6 +3,7 @@ from qforte import qforte as qf
 
 class BasisTest(unittest.TestCase):
     def test_str(self):
+        print('\nSTART test_str\n')
         self.assertEqual(str(qf.QubitBasis(0)), "|0000000000000000000000000000000000000000000000000000000000000000>")
         self.assertEqual(str(qf.QubitBasis(5)), "|1010000000000000000000000000000000000000000000000000000000000000>")
 

--- a/tests/build_operator.py
+++ b/tests/build_operator.py
@@ -5,7 +5,7 @@ from openfermion.ops import QubitOperator
 
 class BuilderTests(unittest.TestCase):
     def test_build_from_openfermion(self):
-        print('\n')
+        print('\nSTART test_build_from_openfermion\n')
         trial_state = qforte.Computer(4)
 
         trial_prep = [None]*5

--- a/tests/circ_op_print_test.py
+++ b/tests/circ_op_print_test.py
@@ -8,6 +8,8 @@ from qforte import *
 class Circ_Op_PrintTest(TestCase):
     def test_circ_op_print(self):
 
+        print('\nSTART test_circ_op_print\n')
+
         # initialize empty circuit
         circ1 = qf.Circuit()
         # add (Z1 H2 Y4 X4) Pauli string

--- a/tests/circ_ref_test.py
+++ b/tests/circ_ref_test.py
@@ -12,7 +12,7 @@ import os
 
 class CircuitReferenceTest(unittest.TestCase):
     def test_srqk_with_uccsdpqe_ref(self):
-        print('\n')
+        print('\nSTART test_srqk_with_uccsdpqe_ref\n')
         # The FCI energy of the equidistant H4/STO-3G chain with r = 1.5 angs,.
         Efci = -1.9961503253000235
 

--- a/tests/circuit_test.py
+++ b/tests/circuit_test.py
@@ -5,7 +5,7 @@ import numpy as np
 
 class CircuitTests(unittest.TestCase):
     def test_circuit(self):
-        print('\n')
+        print('\nSTART test_circuit\n')
         num_qubits = 10
 
         qc1 = qforte.Computer(num_qubits)
@@ -47,3 +47,6 @@ class CircuitTests(unittest.TestCase):
         print('-----------------------------')
         print('   ', diff_norm)
         self.assertAlmostEqual(diff_norm, 0.0 + 0.0j)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/comprehensive_gate_test.py
+++ b/tests/comprehensive_gate_test.py
@@ -61,6 +61,7 @@ def circuit_tester(prep, test_circ):
 
 class ComprehensiveGatesTests(unittest.TestCase):
     def test_comp_cX_gates(self):
+        print('\nSTART test_comp_cX_gates\n')
         id = 'cX'
         circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)
 
@@ -77,6 +78,7 @@ class ComprehensiveGatesTests(unittest.TestCase):
             self.assertAlmostEqual(tc_val, 0.0 + 0.0j)
 
     def test_comp_cY_gates(self):
+        print('\nSTART test_comp_cY_gates\n')
         id = 'cY'
         circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)
 
@@ -93,6 +95,7 @@ class ComprehensiveGatesTests(unittest.TestCase):
             self.assertAlmostEqual(tc_val, 0.0 + 0.0j)
 
     def test_comp_cZ_gates(self):
+        print('\nSTART test_comp_cZ_gates\n')
         id = 'cZ'
         circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)
 
@@ -109,6 +112,7 @@ class ComprehensiveGatesTests(unittest.TestCase):
             self.assertAlmostEqual(tc_val, 0.0 + 0.0j)
 
     def test_comp_cR_gates(self):
+        print('\nSTART test_comp_cR_gates\n')
         id = 'cR'
         circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)
 
@@ -125,6 +129,7 @@ class ComprehensiveGatesTests(unittest.TestCase):
             self.assertAlmostEqual(tc_val, 0.0 + 0.0j)
 
     def test_comp_cV_gates(self):
+        print('\nSTART test_comp_cV_gates\n')
         id = 'cV'
         circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)
 
@@ -139,3 +144,6 @@ class ComprehensiveGatesTests(unittest.TestCase):
         for circ in circ_tc:
             tc_val = circuit_tester(prep_circ, circ)
             self.assertAlmostEqual(tc_val, 0.0 + 0.0j)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/custom_pool_test.py
+++ b/tests/custom_pool_test.py
@@ -6,7 +6,7 @@ from qforte.system import system_factory
 class CustomPoolTests(unittest.TestCase):
 
     def test_vqe(self):
-        print('\n')
+        print('\nSTART test_vqe\n')
         Efci = -1.108873060057971
 
         mol = system_factory(system_type = 'molecule',
@@ -18,8 +18,8 @@ class CustomPoolTests(unittest.TestCase):
 
         pool = qf.SQOpPool()
         sq_op = qf.SQOperator()
-        sq_op.add_term( 1, [0, 1], [2, 3]) 
-        sq_op.add_term(-1, [2, 3], [0, 1]) 
+        sq_op.add_term( 1, [0, 1], [2, 3])
+        sq_op.add_term(-1, [2, 3], [0, 1])
         pool.add_term(1, sq_op)
 
         alg = UCCNVQE(mol)

--- a/tests/experiment_test.py
+++ b/tests/experiment_test.py
@@ -3,7 +3,7 @@ from qforte import qforte
 
 class ExperimentTests(unittest.TestCase):
     def test_H2_experiment(self):
-        print('\n')
+        print('\nSTART test_H2_experiment\n')
         #the RHF H2 energy at equilibrium bond length
         E_hf = -1.1166843870661929
 
@@ -62,7 +62,7 @@ class ExperimentTests(unittest.TestCase):
         self.assertLess(experimental_error, 4.0e-4)
 
     def test_H2_experiment_perfect(self):
-        print('\n')
+        print('\nSTART test_H2_experiment_perfect\n')
         #the RHF H2 energy at equilibrium bond length
         E_hf = -1.1166843870661929
 

--- a/tests/fast_qk_test.py
+++ b/tests/fast_qk_test.py
@@ -8,7 +8,7 @@ import numpy as np
 
 class QKDTests(unittest.TestCase):
     def test_H4_fast_qkd(self):
-        print('\n')
+        print('\nSTART test_H4_fast_qkd\n')
         # The FCI energy for H4 at 1.5 Angstrom in a sto-6g basis
         E_fci = -2.0126741263939656
 

--- a/tests/gates_test.py
+++ b/tests/gates_test.py
@@ -8,6 +8,9 @@ def make_basis(str):
 
 class GatesTests(unittest.TestCase):
     def test_X_gate(self):
+
+        print('\nSTART test_X_gate\n')
+
         # test the Pauli X gate
         nqubits = 1
         basis0 = make_basis('0')
@@ -30,6 +33,9 @@ class GatesTests(unittest.TestCase):
 
 
     def test_Y_gate(self):
+
+        print('\nSTART test_Y_gate\n')
+
         # test the Pauli Y gate
         nqubits = 1
         basis0 = make_basis('0')
@@ -52,6 +58,9 @@ class GatesTests(unittest.TestCase):
 
 
     def test_Z_gate(self):
+
+        print('\nSTART test_Z_gate\n')
+
         # test the Pauli Y gate
         nqubits = 1
         basis0 = make_basis('0')
@@ -73,6 +82,9 @@ class GatesTests(unittest.TestCase):
         self.assertAlmostEqual(coeff1, -1.0 + 0.0j)
 
     def test_cX_gate(self):
+
+        print('\nSTART test_cX_gate\n')
+
         # test the cX/CNOT gate
         nqubits = 2
         basis0 = make_basis('00') # basis0:|00>
@@ -135,6 +147,9 @@ class GatesTests(unittest.TestCase):
             self.assertTrue(')' in str(context.exception))
 
     def test_cY_gate(self):
+
+        print('\nSTART test_cY_gate\n')
+
         # test the cY gate
         nqubits = 2
         basis0 = make_basis('00') # basis0:|00>
@@ -194,7 +209,7 @@ class GatesTests(unittest.TestCase):
 
 
     def test_computer(self):
-        print('\n')
+        print('\nSTART test_computer\n')
         # test that 1 - 1 = 0
 
         # print('\n'.join(qc.str()))
@@ -236,6 +251,9 @@ class GatesTests(unittest.TestCase):
        # print(repr(computer))
 
     def test_op_exp_val_1(self):
+
+        print('\nSTART test_op_exp_val_1\n')
+
         # test direct expectation value measurement
         trial_state = qforte.Computer(4)
 

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -3,6 +3,9 @@ from qforte import qforte
 
 class IOTests(unittest.TestCase):
     def test_io_simplified(self):
+
+        print('\nSTART test_io_simplified\n')
+
         # test direct expectation value measurement
         trial_state = qforte.Computer(4)
         trial_circ = qforte.build_circuit('H_0 H_1 H_2 H_3 cX_0_1')

--- a/tests/jw_transform_test.py
+++ b/tests/jw_transform_test.py
@@ -3,6 +3,9 @@ from qforte import qforte
 
 class JordanWignerTests(unittest.TestCase):
     def test_jw1(self):
+
+        print('\nSTART JordanWignerTests\n')
+
         """
         test JW transform of 1.0(2^ 3^ 4 6) + 1.5(1^ 2^ 3 4)
         """
@@ -93,6 +96,9 @@ class JordanWignerTests(unittest.TestCase):
         #TODO: add more jw test cases
 
     def test_jw2(self):
+
+        print('\nSTART test_jw2\n')
+
         coeff_vec = [
             -0.25j,
             -0.25,

--- a/tests/qft_test.py
+++ b/tests/qft_test.py
@@ -3,6 +3,9 @@ import unittest
 
 class QFTTests(unittest.TestCase):
     def test_qft(self):
+
+        print('\nSTART QFTTests\n')
+
         trial_state = Computer(4)
         trial_circ = build_circuit('X_0 X_1')
         trial_state.apply_circuit(trial_circ)

--- a/tests/qite_test.py
+++ b/tests/qite_test.py
@@ -5,7 +5,9 @@ from qforte.ite.qite import QITE
 from qforte.system.molecular_info import Molecule
 
 class QITETests(unittest.TestCase):
-    def test_H2(self):
+    def test_H2_qite(self):
+
+        print('\nSTART test_H2_qite\n')
 
         # The FCI energy for H2 at 1.5 Angstrom in a sto-3g basis
         E_fci = -0.9981493534

--- a/tests/qpea_test.py
+++ b/tests/qpea_test.py
@@ -4,8 +4,8 @@ from qforte.qpea.qpe import QPE
 from qforte.system.molecular_info import Molecule
 
 class QPETests(unittest.TestCase):
-    def test_H2(self):
-        print('\n'),
+    def test_H2_qpe(self):
+        print('\nSTART test_H2_qpe\n'),
         # The FCI energy for H2 at 1.5 Angstrom in a sto-3g basis
         E_fci = -0.9981493534
 

--- a/tests/slow_qk_test.py
+++ b/tests/slow_qk_test.py
@@ -6,7 +6,7 @@ from qforte.system.molecular_info import Molecule
 
 class PhysicalQKDTests(unittest.TestCase):
     def test_H4_physical_qkd(self):
-        print('\n')
+        print('\nSTART test_H4_physical_qkd\n')
         # The FCI energy for H4 at 1.5 Angstrom in a sto-6g basis
         E_fci = -2.0126741263939656
 

--- a/tests/sparse_op_test.py
+++ b/tests/sparse_op_test.py
@@ -4,6 +4,9 @@ import numpy as np
 
 class SparseOpTests(unittest.TestCase):
     def test_sparse_operator(self):
+
+        print('\nSTART test_sparse_operator\n')
+
         """
         test the SparseMatrix and SparseVector classes
         """

--- a/tests/spqe_test.py
+++ b/tests/spqe_test.py
@@ -11,7 +11,7 @@ data_path = os.path.join(THIS_DIR, 'H4-sto6g-075a.json')
 
 class SPQETests(unittest.TestCase):
     def test_H4_spqe_exact(self):
-        print('\n')
+        print('\nSTART test_H4_spqe_exact\n')
 
         # The FCI energy for H4 at 0.75 Angstrom in a sto-6g basis
         Efci = -2.1628978832666865

--- a/tests/test_cpp.py
+++ b/tests/test_cpp.py
@@ -5,6 +5,7 @@ import os
 class MainTest(unittest.TestCase):
     def test_cpp(self):
         print("\n\nTesting C++ code...")
+        print('\nSTART test_cpp\n')
         subprocess.check_call(os.path.join(os.path.dirname(
             os.path.relpath(__file__)), 'bin', 'qforte_test'))
         print()  # for prettier output

--- a/tests/trotter_test.py
+++ b/tests/trotter_test.py
@@ -5,6 +5,8 @@ from qforte import qforte
 class ExperimentTests(unittest.TestCase):
     def test_trotterization(self):
 
+        print('\nSTART test_trotterization\n')
+
         circ_vec = [qforte.Circuit(), qforte.build_circuit('Z_0')]
         coef_vec = [-1.0j * 0.5, -1.0j * -0.04544288414432624]
 
@@ -39,6 +41,8 @@ class ExperimentTests(unittest.TestCase):
         self.assertAlmostEqual(np.imag(coeffs[12]),  0.25349397560041553)
 
     def test_trotterization_with_controlled_U(self):
+
+        print('\nSTART test_trotterization_with_controlled_U\n')
 
         circ_vec = [qforte.build_circuit('Y_0 X_1'), qforte.build_circuit('X_0 Y_1')]
         coef_vec = [-1.0719145972781818j, 1.0719145972781818j]

--- a/tests/uccsd_test.py
+++ b/tests/uccsd_test.py
@@ -14,7 +14,7 @@ data_path = os.path.join(THIS_DIR, 'He-ccpvdz.json')
 
 class UccTests(unittest.TestCase):
     def test_He_uccsd_vqe_exact(self):
-        print('\n')
+        print('\nSTART test_He_uccsd_vqe_exact\n')
         # The FCI energy for He atom in a cc-pvdz basis
         Efci = -2.887594831090938
 
@@ -32,7 +32,7 @@ class UccTests(unittest.TestCase):
         self.assertAlmostEqual(Egs_elec, Efci, 10)
 
     def test_He_uccsd_vqe_exact_diis(self):
-        print('\n')
+        print('\nSTART test_He_uccsd_vqe_exact_diis\n')
         # The FCI energy for He atom in a cc-pvdz basis
         Efci = -2.887594831090938
 
@@ -51,7 +51,7 @@ class UccTests(unittest.TestCase):
         self.assertAlmostEqual(Egs_elec, Efci, 11)
 
     def test_He_uccsd_vqe_exact_psi(self):
-        print('\n')
+        print('\nSTART test_He_uccsd_vqe_exact_psi\n')
         # The FCI energy for He atom in a cc-pvdz basis
         Efci = -2.887594831090938
 
@@ -69,7 +69,7 @@ class UccTests(unittest.TestCase):
         self.assertAlmostEqual(Egs_elec, Efci, 10)
 
     def test_He_uccsd_vqe_frozen_virtual(self):
-        print('\n')
+        print('\nSTART test_He_uccsd_vqe_frozen_virtual\n')
         # The FCI energy for He atom in a cc-pvdz basis, according to Psi, one frozen virtual
         Efci = -2.881925090255593
 
@@ -87,7 +87,7 @@ class UccTests(unittest.TestCase):
         self.assertAlmostEqual(Egs_elec, Efci, 11)
 
     def test_He_uccsd_pqe_exact(self):
-        print('\n')
+        print('\nSTART test_He_uccsd_pqe_exact\n')
         # The FCI energy for He atom in a cc-pvdz basis
         Efci = -2.887594831090938
 


### PR DESCRIPTION
## Description
I added print statements in the tests files. Now, once each test begins, it will first print the name of the test. This will be useful for debugging purposes when running `python setup.py test`.

I also renamed a couple of tests that had the same name. The new names specify the particular method that is being tested.
 
All tests passed on my machine.

## Checklist
- [ x] Added/updated tests of new features
- [ x] Ready to go!
