### PR TITLE
Fixes bug introduced by PR #137

### DIFF
--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -9,7 +9,6 @@ import qforte as qf
 from abc import abstractmethod
 from qforte.abc.pqeabc import PQE
 from qforte.abc.ansatz import UCC
-from qforte.utils.op_pools import *
 
 from qforte.experiment import *
 from qforte.utils.transforms import *

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -9,7 +9,6 @@ import qforte as qf
 from abc import abstractmethod
 from qforte.abc.vqeabc import VQE
 from qforte.abc.ansatz import UCC
-from qforte.utils.op_pools import *
 
 from qforte.experiment import *
 from qforte.utils.transforms import *
@@ -66,7 +65,7 @@ class UCCVQE(VQE, UCC):
         Whether or not to use an analytic function for the gradient to pass to
         the optimizer. If false, the optimizer will use self-generated approximate
         gradients from finite differences (if BFGS algorithm is used).
-        
+
     """
 
     @abstractmethod

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -11,7 +11,6 @@ import qforte as qf
 from qforte.abc.uccvqeabc import UCCVQE
 from qforte.experiment import *
 from qforte.utils.transforms import *
-from qforte.utils.op_pools import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
 

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -9,7 +9,6 @@ import qforte as qf
 from qforte.abc.uccpqeabc import UCCPQE
 from qforte.experiment import *
 from qforte.utils.transforms import *
-from qforte.utils.op_pools import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
 

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -11,7 +11,6 @@ from qforte.abc.uccpqeabc import UCCPQE
 from qforte.experiment import *
 from qforte.maths import optimizer
 from qforte.utils.transforms import *
-from qforte.utils.op_pools import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
 

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -11,7 +11,6 @@ from qforte.abc.uccvqeabc import UCCVQE
 from qforte.experiment import *
 from qforte.maths import optimizer
 from qforte.utils.transforms import *
-from qforte.utils.op_pools import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
 

--- a/src/qforte/utils/__init__.py
+++ b/src/qforte/utils/__init__.py
@@ -3,6 +3,5 @@ from .trotterization import *
 from .transforms import *
 from .qft import *
 from .state_prep import *
-from .op_pools import *
 from .exp_ops import *
 from .point_groups import *


### PR DESCRIPTION
## Description
In PR #137 the op_pools module was deleted, but various import statements pertaining to it were left in the code. The erroneous import statements were removed. All tests passed successfully.

## Checklist
- [x ] Checked for redundant headers/imports
- [x ] Ready to go!
