### PR TITLE
Define SQOpPool.__len__

### DIFF
--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -201,7 +201,7 @@ class UCCVQE(VQE, UCC):
             raise ValueError("self._fast must be True for gradient measurement.")
 
         # Initialize amplitudes
-        M = len(self._pool)
+        M = len(self._pool_obj)
         pool_amps = np.zeros(M)
         for tamp, top in zip(self._tamps, self._tops):
             pool_amps[top] = tamp

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -63,6 +63,7 @@ PYBIND11_MODULE(qforte, m) {
              py::arg("combine_like_terms") = true)
         .def("fill_pool", &SQOpPool::fill_pool)
         .def("str", &SQOpPool::str)
+        .def("__len__", [](const SQOpPool &pool) { return pool.terms().size(); })
         .def("__str__", &SQOpPool::str)
         .def("__repr__", &SQOpPool::str);
 

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -249,7 +249,7 @@ class ADAPTVQE(UCCVQE):
         print('\n\n                ==> ADAPT-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final ADAPT-VQE Energy:                     ', round(self._Egs, 10))
-        print('Number of operators in pool:                 ', len(self._pool))
+        print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Total number of Hamiltonian measurements:    ', self.get_num_ham_measurements())
         print('Total number of commutator measurements:      ', self.get_num_commut_measurements())
@@ -419,7 +419,7 @@ class ADAPTVQE(UCCVQE):
         return self._n_ham_measurements
 
     def get_num_commut_measurements(self):
-        self._n_commut_measurements += len(self._tamps) * len(self._pool)
+        self._n_commut_measurements += len(self._tamps) * len(self._pool_obj)
 
         if self._use_analytic_grad:
             for m, res in enumerate(self._results):

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -207,6 +207,8 @@ class SPQE(UCCPQE):
         print('\n\n                ==> SPQE summary <==')
         print('-----------------------------------------------------------')
         print('Final SPQE Energy:                           ', round(self._Egs, 10))
+        # TODO: Change below to len(self._pool_obj) when the _pool object is synchronized
+        # with the _pool_obj object again.
         print('Number of operators in pool:                 ', len(self._pool))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Number of classical parameters used:         ', self._n_classical_params)

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -149,7 +149,7 @@ class UCCNPQE(UCCPQE):
         print('\n\n                   ==> UCC-PQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-PQE Energy:                      ', round(self._Egs, 10))
-        print('Number of operators in pool:                 ', len(self._pool))
+        print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Number of classical parameters used:         ', len(self._tamps))
         print('Number of non-zero parameters used:          ', self._n_nonzero_params)
@@ -270,7 +270,7 @@ class UCCNPQE(UCCPQE):
         """Adds all operators in the pool to the list of operators in the circuit,
         with amplitude 0.
         """
-        for l in range(len(self._pool)):
+        for l in range(len(self._pool_obj)):
             self._tops.append(l)
             self._tamps.append(0.0)
 

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -146,7 +146,7 @@ class UCCNVQE(UCCVQE):
         print('\n\n                ==> UCCN-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-VQE Energy:                      ', round(self._Egs, 10))
-        print('Number of operators in pool:                 ', len(self._pool))
+        print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Total number of Hamiltonian measurements:    ', self.get_num_ham_measurements())
         print('Total number of commutator measurements:     ', self.get_num_commut_measurements())
@@ -241,8 +241,8 @@ class UCCNVQE(UCCVQE):
         """Adds all operators in the pool to the list of operators in the circuit,
         with amplitude 0.
         """
-        self._tops = list(range(len(self._pool)))
-        self._tamps = [0.0] * len(self._pool)
+        self._tops = list(range(len(self._pool_obj)))
+        self._tamps = [0.0] * len(self._pool_obj)
 
     # TODO: change to get_num_pt_evals
     def get_num_ham_measurements(self):
@@ -259,7 +259,7 @@ class UCCNVQE(UCCVQE):
     # TODO: depricate this function
     def get_num_commut_measurements(self):
         # if self._use_analytic_grad:
-        #     self._n_commut_measurements = self._final_result.njev * (len(self._pool))
+        #     self._n_commut_measurements = self._final_result.njev * (len(self._pool_obj))
         #     return self._n_commut_measurements
         # else:
         #     return 0

--- a/tests/test_custom_pool.py
+++ b/tests/test_custom_pool.py
@@ -14,10 +14,12 @@ class TestCustomPool:
                                      symmetry = "d2h")
 
         pool = SQOpPool()
+        assert len(pool) == 0
         sq_op = SQOperator()
         sq_op.add_term( 1, [0, 1], [2, 3])
         sq_op.add_term(-1, [2, 3], [0, 1])
         pool.add_term(1, sq_op)
+        assert len(pool) == 1
 
         alg = UCCNVQE(mol)
         alg.run(pool_type = pool,


### PR DESCRIPTION
## Description
Binds a `__len__` magic method so that `len(SQOpPool)` is the number of terms in the pool. This finishes item 2B of #144 and accomplishes part of item 3.

## User Notes
- [x] Defined `len(SQOpPool)`

## Checklist
- [x] Added/updated tests of new features
- [x] Ready to go!
