### PR TITLE
Magic methods for SQOpPool

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -63,6 +63,9 @@ PYBIND11_MODULE(qforte, m) {
              py::arg("combine_like_terms") = true)
         .def("fill_pool", &SQOpPool::fill_pool)
         .def("str", &SQOpPool::str)
+        .def("__getitem__", [](const SQOpPool &pool, size_t i) { return pool.terms()[i]; })
+        .def("__iter__", [](const SQOpPool &pool) { return py::make_iterator(pool.terms()); },
+            py::keep_alive<0, 1>())
         .def("__len__", [](const SQOpPool &pool) { return pool.terms().size(); })
         .def("__str__", &SQOpPool::str)
         .def("__repr__", &SQOpPool::str);

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -345,7 +345,7 @@ class ADAPTVQE(UCCVQE):
 
             curr_norm += grad_m ** 2
             if (self._verbose):
-                print(f'       {m:3}                {self._Nm[m]:8}             {grad_m:+12.9f}      {self._pool[m][1].terms()[0][1]}')
+                print(f'       {m:3}                {self._Nm[m]:8}             {grad_m:+12.9f}      {self._pool_obj[m][1].terms()[0][1]}')
 
             if (abs(grad_m) > abs(lgrst_grad)):
 

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -163,7 +163,7 @@ class UCCNPQE(UCCPQE):
         self.diis_solve(self.get_residual_vector)
 
     def fill_excited_dets(self):
-        for _, sq_op in self._pool:
+        for _, sq_op in self._pool_obj:
             # 1. Identify the excitation operator
             # occ => i,j,k,...
             # vir => a,b,c,...
@@ -233,7 +233,7 @@ class UCCNPQE(UCCPQE):
 
         temp_pool = qforte.SQOpPool()
         for param, top in zip(trial_amps, self._tops):
-            temp_pool.add(param, self._pool[top][1])
+            temp_pool.add(param, self._pool_obj[top][1])
 
         A = temp_pool.get_qubit_operator('commuting_grp_lex')
         U, U_phase = trotterize(A, trotter_number=self._trotter_number)

--- a/tests/test_custom_pool.py
+++ b/tests/test_custom_pool.py
@@ -14,12 +14,10 @@ class TestCustomPool:
                                      symmetry = "d2h")
 
         pool = SQOpPool()
-        assert len(pool) == 0
         sq_op = SQOperator()
         sq_op.add_term( 1, [0, 1], [2, 3])
         sq_op.add_term(-1, [2, 3], [0, 1])
         pool.add_term(1, sq_op)
-        assert len(pool) == 1
 
         alg = UCCNVQE(mol)
         alg.run(pool_type = pool,

--- a/tests/test_sq_pool.py
+++ b/tests/test_sq_pool.py
@@ -1,0 +1,18 @@
+from qforte import SQOpPool, SQOperator
+
+class TestSqPool:
+    def test_terms(self):
+        pool = SQOpPool()
+        terms = pool.terms()
+        assert len(terms) == 0
+        assert len(pool) == 0
+        sq_op = SQOperator()
+        sq_op.add_term( 1, [0, 1], [2, 3])
+        sq_op.add_term(-1, [2, 3], [0, 1])
+        pool.add_term(1, sq_op)
+        assert len(pool) == 1
+        assert len(terms) == 0
+
+        for coefficient, operator in pool:
+            assert isinstance(coefficient, complex)
+            assert isinstance(operator, SQOperator)


### PR DESCRIPTION
## Description
Finishes 2A, 2C, and part of 3 of issue #144.

Once this is in, the next step is the SPQE refactor.

## User Notes
- [x] `SQPoolObj` now supports `__getitem__` and `__iter__`

## Checklist
- [x] Added/updated tests of new features
- [x] Tested that new bindings are Jupyter compatible.
- [x] Ready to go!
