### PR TITLE
Added frozen orbital functionality for system_type = molecule

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -75,6 +75,10 @@ class Algorithm(ABC):
                  print_summary_file=False,
                  **kwargs):
 
+        if isinstance(self, qf.QPE) and hasattr(system, 'frozen_core'):
+            if system.frozen_core + system.frozen_virtual > 0:
+                raise ValueError("QPE with frozen orbitals is not currently supported.")
+
         self._sys = system
         self._state_prep_type = state_prep_type
 
@@ -107,9 +111,6 @@ class Algorithm(ABC):
             self._hf_energy = system.hf_energy
         except AttributeError:
             self._hf_energy = 0.0
-
-        if hasattr(system, 'frozen_core_energy'):
-            self._frozen_core_energy = system.frozen_core_energy
 
         self._Nl = len(self._qb_ham.terms())
         self._trotter_order = trotter_order

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -108,6 +108,9 @@ class Algorithm(ABC):
         except AttributeError:
             self._hf_energy = 0.0
 
+        if hasattr(system, 'frozen_core_energy'):
+            self._frozen_core_energy = system.frozen_core_energy
+
         self._Nl = len(self._qb_ham.terms())
         self._trotter_order = trotter_order
         self._trotter_number = trotter_number

--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -47,6 +47,10 @@ def create_psi_mol(**kwargs):
     if not use_psi4:
         raise ImportError("Psi4 was not imported correctely.")
 
+    # By default, the number of frozen orbitals is set to zero
+    kwargs.setdefault('num_frozen_docc', 0)
+    kwargs.setdefault('num_frozen_uocc', 0)
+
     # run_scf is not read, because we always run SCF to get a wavefunction object.
     kwargs.setdefault('run_mp2', 0)
     kwargs.setdefault('run_ccsd', 0)
@@ -76,28 +80,12 @@ def create_psi_mol(**kwargs):
               'reference' : scf_ref_type,
               'e_convergence': 1e-8,
               'd_convergence': 1e-8,
-              'ci_maxiter': 100})
+              'ci_maxiter': 100,
+              'num_frozen_docc' : kwargs['num_frozen_docc'],
+              'num_frozen_uocc' : kwargs['num_frozen_uocc']})
 
     # run psi4 caclulation
     p4_Escf, p4_wfn = psi4.energy('SCF', return_wfn=True)
-
-    # Get symmetry information
-    orbitals = []
-    for irrep, block in enumerate(p4_wfn.epsilon_a().nph):
-        for orbital in block:
-            orbitals.append([orbital, irrep])
-
-    orbitals.sort()
-    hf_orbital_energies = []
-    orb_irreps_to_int = []
-    for row in orbitals:
-        hf_orbital_energies.append(row[0])
-        orb_irreps_to_int.append(row[1])
-    del orbitals
-
-    point_group = p4_mol.symmetry_from_input().lower()
-    irreps = p4_mol.irrep_labels()
-    orb_irreps = [irreps[i] for i in orb_irreps_to_int]
 
     # Run additional computations requested by the user
     if(kwargs['run_mp2']):
@@ -130,30 +118,70 @@ def create_psi_mol(**kwargs):
     nalpha = p4_wfn.nalpha()
     nbeta = p4_wfn.nbeta()
     nel = nalpha + nbeta
+    frozen_core = sum(p4_wfn.frzcpi().to_tuple())
+    frozen_virtual = sum(p4_wfn.frzvpi().to_tuple())
+
+    # Get symmetry information
+    orbitals = []
+    for irrep, block in enumerate(p4_wfn.epsilon_a().nph):
+        for orbital in block:
+            orbitals.append([orbital, irrep])
+
+    orbitals.sort()
+    hf_orbital_energies = []
+    orb_irreps_to_int = []
+    for row in orbitals[frozen_core : nmo - frozen_virtual]:
+        hf_orbital_energies.append(row[0])
+        orb_irreps_to_int.append(row[1])
+    del orbitals
+
+    point_group = p4_mol.symmetry_from_input().lower()
+    irreps = p4_mol.irrep_labels()
+    orb_irreps = [irreps[i] for i in orb_irreps_to_int]
+
+    # If frozen_core > 0, compute the frozen core energy and transform one-electron integrals
+
+    frozen_core_energy = 0
+
+    if frozen_core > 0:
+        for i in range(frozen_core):
+            frozen_core_energy += 2 * mo_oeis[i, i]
+
+        # Note that the two-electron integrals out of Psi4 are in the Mulliken notation
+        for i in range(frozen_core):
+            for j in range(frozen_core):
+                frozen_core_energy += 2 * mo_teis[i, i, j, j] - mo_teis[i, j, j, i]
+
+        # Incorporate in the one-electron integrals the two-electron integrals involving both frozen and non-frozen orbitals.
+        # This also ensures that the correct orbital energies will be obtained.
+
+        for p in range(frozen_core, nmo - frozen_virtual):
+            for q in range(frozen_core, nmo - frozen_virtual):
+                for i in range(frozen_core):
+                    mo_oeis[p, q] += 2 * mo_teis[p, q, i, i] - mo_teis[p, i, i, q]
 
     # Make hf_reference
-    hf_reference = [1] * nel + [0] * (2 * nmo - nel)
+    hf_reference = [1] * (nel - 2 * frozen_core) + [0] * (2 * (nmo - frozen_virtual) - nel)
 
     # Build second quantized Hamiltonian
-    nmo = np.shape(mo_oeis)[0]
     Hsq = qforte.SQOperator()
-    Hsq.add(p4_Enuc_ref, [], [])
-    for i in range(nmo):
-        ia = i*2
-        ib = i*2 + 1
-        for j in range(nmo):
-            ja = j*2
-            jb = j*2 + 1
+    Hsq.add(p4_Enuc_ref + frozen_core_energy, [], [])
+    for i in range(frozen_core, nmo - frozen_virtual):
+        ia = (i - frozen_core)*2
+        ib = (i - frozen_core)*2 + 1
+        for j in range(frozen_core, nmo - frozen_virtual):
+            ja = (j - frozen_core)*2
+            jb = (j - frozen_core)*2 + 1
 
             Hsq.add(mo_oeis[i,j], [ia], [ja])
             Hsq.add(mo_oeis[i,j], [ib], [jb])
 
-            for k in range(nmo):
-                ka = k*2
-                kb = k*2 + 1
-                for l in range(nmo):
-                    la = l*2
-                    lb = l*2 + 1
+            for k in range(frozen_core, nmo - frozen_virtual):
+                ka = (k - frozen_core)*2
+                kb = (k - frozen_core)*2 + 1
+                for l in range(frozen_core, nmo - frozen_virtual):
+                    la = (l - frozen_core)*2
+                    lb = (l - frozen_core)*2 + 1
 
                     if(ia!=jb and kb != la):
                         Hsq.add( mo_teis[i,l,k,j]/2, [ia, jb], [kb, la] ) # abba
@@ -175,6 +203,9 @@ def create_psi_mol(**kwargs):
     qforte_mol.orb_irreps = orb_irreps
     qforte_mol.orb_irreps_to_int = orb_irreps_to_int
     qforte_mol.hf_orbital_energies = hf_orbital_energies
+    qforte_mol.frozen_core = frozen_core
+    qforte_mol.frozen_virtual = frozen_virtual
+    qforte_mol.frozen_core_energy = frozen_core_energy
 
     # Order Psi4 to delete its temporary files.
     psi4.core.clean()

--- a/src/qforte/system/molecular_info.py
+++ b/src/qforte/system/molecular_info.py
@@ -84,6 +84,17 @@ class Molecule(System):
         It contains the RHF orbital energies (in hartree) of the system, as computed by Psi4.
         In the case of H2/STO-3G, r = 3.0 angs, for example: hf_orbital_energies = [-0.1805392218304829, 0.018071329565966215]
 
+    ###### Attributes pertaining to frozen-orbital approximations ######
+
+    frozen_core : integer
+        Number of lowest-energy frozen core orbitals.
+
+    frozen_virtual : integer
+        Number of highest-energy frozen virtual orbitals.
+
+    frozen_core_energy: float
+        The contribution to the Hartree-Fock energy associated with the frozen core orbitals
+
     """
 
     def __init__(self, mol_geometry=None, basis='sto-3g', multiplicity=1, charge=0,
@@ -189,3 +200,27 @@ class Molecule(System):
     @hf_orbital_energies.setter
     def hf_orbital_energies(self, hf_orbital_energies):
         self._hf_orbital_energies = hf_orbital_energies
+
+    @property
+    def frozen_core(self):
+        return self._frozen_core
+
+    @frozen_core.setter
+    def frozen_core(self, frozen_core):
+        self._frozen_core = frozen_core
+
+    @property
+    def frozen_virtual(self):
+        return self._frozen_virtual
+
+    @frozen_virtual.setter
+    def frozen_virtual(self, frozen_virtual):
+        self._frozen_virtual = frozen_virtual
+
+    @property
+    def frozen_core_energy(self):
+        return self._frozen_core_energy
+
+    @frozen_core_energy.setter
+    def frozen_core_energy(self, frozen_core_energy):
+        self._frozen_core_energy = frozen_core_energy

--- a/tests/test_freeze_orb.py
+++ b/tests/test_freeze_orb.py
@@ -1,0 +1,36 @@
+import pytest
+from pytest import approx
+from qforte import system_factory, UCCNVQE, ADAPTVQE, UCCNPQE, SPQE
+
+class TestFreezingOrbitals():
+
+    @pytest.mark.parametrize("method, options", [
+        (UCCNVQE, {"pool_type" : 'SDTQ'}),
+        (ADAPTVQE, {"pool_type" : 'SDTQ', "avqe_thresh" : 1.0e-3}),
+        (UCCNPQE, {"pool_type" : 'SDTQ'}),
+        (SPQE, {})
+        ])
+    def test_freeze_orb_ucc(self, method, options):
+
+        mol = system_factory(system_type = 'molecule',
+                                     build_type = 'psi4',
+                                     basis = 'sto-3g',
+                                     mol_geometry = [('Be', (0, 0, -1.2)),
+                                                     ('Be', (0, 0,  1.2))],
+                                     symmetry = 'd2h',
+                                     num_frozen_docc = 2,
+                                     num_frozen_uocc = 3)
+
+        alg = method(mol)
+
+        alg.run(**options)
+
+        Egs = alg.get_gs_energy()
+        # WARNING: Due to a bug in Psi4, the energies stored in the fci_energy attrbitute of the Molecule class are not
+        #          correct when the number of frozen virtual orbitals is larger than zero.
+        Efci = -28.747184707540754
+
+        if method is SPQE:
+            assert Egs == approx(Efci, abs=1.0e-4)
+        else:
+            assert Egs == approx(Efci, abs=1.0e-10)

--- a/tests/test_freeze_orb.py
+++ b/tests/test_freeze_orb.py
@@ -8,7 +8,7 @@ class TestFreezingOrbitals():
         (UCCNVQE, {"pool_type" : 'SDTQ'}),
         (ADAPTVQE, {"pool_type" : 'SDTQ', "avqe_thresh" : 1.0e-3}),
         (UCCNPQE, {"pool_type" : 'SDTQ'}),
-        (SPQE, {})
+        (SPQE, {"spqe_thresh" : 1.0e-4, "dt" : 0.0001})
         ])
     def test_freeze_orb_ucc(self, method, options):
 
@@ -30,7 +30,4 @@ class TestFreezingOrbitals():
         #          correct when the number of frozen virtual orbitals is larger than zero.
         Efci = -28.747184707540754
 
-        if method is SPQE:
-            assert Egs == approx(Efci, abs=1.0e-4)
-        else:
-            assert Egs == approx(Efci, abs=1.0e-10)
+        assert Egs == approx(Efci, abs=1.0e-10)


### PR DESCRIPTION
## Description
Modified the one- and two-electron integrals out of Psi4 to allow for freezing core and/or virtual orbitals. In doing so, I defined three new attributes to the Molecule class, called frozen_core, frozen_virtual, and frozen_core_energy.

WARNING: When freezing virtual orbitals, the FCI energy stored in the attribute fci_energy of the Molecule class is not correct, 
                   since it is obtained by Psi4 assuming no frozen virtuals. This issue has been communicated to the Psi4 community 
                   by @JonathonMisiewicz (Psi4 issue #2295). Nevertheless, this information is never used in the code, so for the time 
                   being there is no harm done.

## User Notes
- [x] Features added

## Checklist
- [x] Added/updated tests of new features
- [x] Documented source code
- [x] All tests passed successfully
- [x] Ready to go!
