### PR TITLE
Use ansatz_circuit

### DIFF
--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -231,14 +231,7 @@ class UCCNPQE(UCCPQE):
         if(self._pool_type == 'sa_SD'):
             raise ValueError('Must use single term particle-hole nbody operators for residual calculation')
 
-        temp_pool = qforte.SQOpPool()
-        for param, top in zip(trial_amps, self._tops):
-            temp_pool.add(param, self._pool_obj[top][1])
-
-        A = temp_pool.get_qubit_operator('commuting_grp_lex')
-        U, U_phase = trotterize(A, trotter_number=self._trotter_number)
-        if U_phase != 1.0 + 0.0j:
-            raise ValueError("Encountered phase change, phase not equal to (1.0 + 0.0i)")
+        U = self.ansatz_circuit(trial_amps)
 
         qc_res = qforte.Computer(self._nqb)
         qc_res.apply_circuit(self._Uprep)


### PR DESCRIPTION
## Description
Eliminates some code duplication by invoking `ansatz_circuit`. There's more repetition to remove, but this reduces the number of `_pool`/`_pool_obj` calls I need to track, which is what I need right now.

Also removes the unused `_commutator_pool` attribute of `SPQE`.

## Checklist
- [x] Tests pass
- [x] Ready to go!
