### PR TITLE
Added feature to find the Z2 symmetries of the Hamiltonian.

### DIFF
--- a/src/qforte/utils/__init__.py
+++ b/src/qforte/utils/__init__.py
@@ -5,3 +5,4 @@ from .qft import *
 from .state_prep import *
 from .exp_ops import *
 from .point_groups import *
+from .qbt_tapering import *

--- a/src/qforte/utils/__init__.py
+++ b/src/qforte/utils/__init__.py
@@ -5,4 +5,4 @@ from .qft import *
 from .state_prep import *
 from .exp_ops import *
 from .point_groups import *
-from .qbt_tapering import *
+from .qubit_tapering import *

--- a/src/qforte/utils/qbt_tapering.py
+++ b/src/qforte/utils/qbt_tapering.py
@@ -265,16 +265,23 @@ def qubit_tapering_oprtr(tapered_qubits, sign, operator, unitary):
 
     # Similarity transform the given operator using the fact that the unitary matrix is also Hermitian
 
+    ## This is necessary; otherwise later on we would be modifying the "unitary" object directly, which we do not want to do
     unitary_tmp = qf.QubitOperator()
     unitary_tmp.add_op(unitary)
-    operator.operator_product(unitary_tmp, True, True)
-    unitary_tmp.operator_product(operator, True, True)
-    operator = unitary_tmp
+
+    ## This is necessary; if we do not do this, when transforming the Hamiltonian we would be changing the "hamiltonian"
+    ## attribute of the Molecule class to nonsense.
+    operator_tmp = qf.QubitOperator()
+    operator_tmp.add_op(operator)
+
+    operator_tmp.operator_product(unitary_tmp, True, True)
+    unitary_tmp.operator_product(operator_tmp, True, True)
+    operator_tmp = unitary_tmp
 
     # Create a QForte QubitOperator object that will store the tapered operator
     operator_tapered = qf.QubitOperator()
 
-    for i, (coeff, circuit) in enumerate(operator.terms()):
+    for i, (coeff, circuit) in enumerate(operator_tmp.terms()):
         # Create circuit that will store the pauli string with gates corresponding to qubits to be tapered off removed
         circ = qf.Circuit()
         # List that will store the coefficients modified according to the sign structure provided by the user

--- a/src/qforte/utils/qbt_tapering.py
+++ b/src/qforte/utils/qbt_tapering.py
@@ -210,7 +210,7 @@ def find_Z2_symmetries(hamiltonian, qiskit_order = False):
 
     reorder = np.argsort(sigma_x)
     sigma_x = sigma_x[reorder][::-1]
-    gnrtrs = [gnrtrs[i] for i in reorder]
+    gnrtrs = [gnrtrs[i] for i in reorder[::-1]]
 
     ## Construct individual unitary matrices
     untrs = []

--- a/src/qforte/utils/qbt_tapering.py
+++ b/src/qforte/utils/qbt_tapering.py
@@ -1,0 +1,318 @@
+"""
+Functions for performing qubit tapering based on the Z2 symmetries of the qubit Hamiltonian
+"""
+
+import qforte as qf
+import numpy as np
+from itertools import product
+
+def find_Z2_symmetries(hamiltonian, qiskit_order = False):
+
+    """
+    This function computes the Z2 symmetries of the Hamiltonian, identifies the ID numbers of the qubits to
+    be tapered off, provides the corresponding sign structures, and constructs the necessary unitary operators.
+    It is based on the qubit tapering approach reported in https://arxiv.org/abs/1701.08213.
+
+    Arguments:
+
+    hamiltonian: QubitOperator
+        The qubit Hamiltonian whose Z2 symmetries we want to find.
+
+    qiskit_order: bool
+        If True, the qubits to be tapered off will have the smallest id numbers possible, as is done in Qiskit.
+        If False, the qubits to be tapered off will have the largest id numbers possible. This is the default,
+        since it leads to less operations once the qubits are removed.
+    """
+
+    # The algorithm consists of the following steps:
+    # 1) Convert qubit Hamiltonian to binary matrix, called the parity check matrix E
+    # 2) Find the basis of the kernel of the parity check matrix, ker{E}
+    # 3) Find maximal Abelian subgroup of the basis of ker{E}
+    # 4) Construct unitary matrices that will be used in the qubit_tapering algorithm
+    # 5) Compute the various signs corresponding to the eigenvalues of the sigma_x operators that will be removed
+
+    # 1) Convert qubit Hamiltonian to binary matrix
+
+    ## Obtain number of qubits and number of Pauli strings contained in qubit Hamiltonian
+    n_qubits = hamiltonian.num_qubits()
+    n_strings = len(hamiltonian.terms())
+
+    ## Construct parity check matrix
+    prt_chck_mtrx = np.zeros((n_strings, 2 * n_qubits), dtype=np.uint8)
+    for i, string in enumerate(hamiltonian.terms()):
+        for pauli in string[1].gates():
+            XYZ_gate = pauli.gate_id()
+            trgt = pauli.target()
+            if XYZ_gate == 'Z':
+                prt_chck_mtrx[i, n_qubits - trgt - 1] = 1
+            elif XYZ_gate == 'X':
+                prt_chck_mtrx[i, 2 * n_qubits - trgt - 1] = 1
+            else:
+                prt_chck_mtrx[i, n_qubits - trgt - 1] = 1
+                prt_chck_mtrx[i, 2 * n_qubits - trgt - 1] = 1
+
+    # 2) Find the basis of the kernel of the parity check matrix, ker{E}
+    # See https://en.wikipedia.org/wiki/Kernel_(linear_algebra)#Computation_by_Gaussian_elimination
+
+    ## Augment the (n_strings) × (2 * n_qubits) parity check matrix by the (2 * n_qubits) × (2 * n_qubits) identity matrix
+
+    prt_chck_mtrx_aug = np.concatenate((prt_chck_mtrx, np.identity(2 * n_qubits, dtype=np.uint8)), axis=0)
+
+    ## Find column echelon form (CEF) of augmented matix.
+
+    idx = 0
+    for row in range(n_strings):
+        ### Find a non-zero row
+        if np.any(prt_chck_mtrx_aug[row,idx:] == 1):
+            ### Find positions of non-zero elements
+            count = np.argwhere(prt_chck_mtrx_aug[row,idx:] == 1)
+            column = int(count[0]) + idx
+            ### Swap columns to bring first non-zero element in this row immediately to the right of that of the previous row
+            prt_chck_mtrx_aug[:, [column , idx]] = prt_chck_mtrx_aug[:, [idx, column]]
+            ### Eliminate remaining non-zero elements in the submatrix
+            for i in range(1,count.shape[0]):
+                column2 = int(count[i]) + idx
+                prt_chck_mtrx_aug[:,column2] = np.bitwise_xor(prt_chck_mtrx_aug[:, idx], prt_chck_mtrx_aug[:,column2])
+            ### decrease the number of columns that need to be checked
+            idx += 1
+
+    ## Find basis vectors of kernel by checking for zero columns in the CEF of the parity check matrix
+
+    dim = 0
+    basis = np.zeros((1, 2 * n_qubits), dtype=np.uint8)
+    for column in range(2 * n_qubits):
+        row = n_strings
+        if not np.any(prt_chck_mtrx_aug[:row, column]):
+            if dim == 0:
+                basis = prt_chck_mtrx_aug[row:, column].reshape((1,2 * n_qubits))
+                dim += 1
+            else:
+                basis = np.concatenate((basis, prt_chck_mtrx_aug[row:, column].reshape((1,2 * n_qubits))), axis=0)
+
+    # 3) Find maximal Abelian subgroup of the basis of ker{E}
+    # This is done using the symplectic bilinear form B that the binary vector space is equipped with:
+    # B(v,w) = v * B * w.T,
+    # where v and w are binary vectors and B is the matrix of the bilinear form.
+
+    ## Construct matrix of bilinear form.
+
+    top = np.concatenate((np.zeros((n_qubits, n_qubits), dtype=np.uint8), np.identity(n_qubits, dtype=np.uint8)), axis=1)
+    bottom = np.concatenate((np.identity(n_qubits, dtype=np.uint8), np.zeros((n_qubits, n_qubits), dtype=np.uint8)), axis=1)
+    blnr_frm_mtrx = np.concatenate((top, bottom), axis=0)
+
+    ## Construct abln matrix.
+    ## abln[i,j] contains the value of the bilinear form betweeen the ith and jth basis vectors of ker{E}
+    ## A "0"/"1" in the ith row and jth column of abln means that the Pauli strings
+    ## associated with the ith and jth binary vectors commute/anticommute.
+
+    aux = np.matmul(blnr_frm_mtrx, basis.T)
+
+    abln = np.zeros((basis.shape[0], basis.shape[0]), dtype=np.uint8)
+    for row in range(basis.shape[0]):
+        for column in range(basis.shape[0]):
+            for idx in range(2*n_qubits):
+                abln[row, column] = (abln[row, column] + basis[row, idx] * aux[idx, column]) % 2
+
+    ## Find the maximal abelian subgroup iteratively. This is done as follows:
+    ## 1) Find non-zero row of abln with smallest Hamming weight.
+    ##    The corresponding basis vector e commutes with most other basis vectors.
+    ## 2) Find basis vectors that do not commute with e and remove them.
+    ## 3) Reconstruct abln matrix with remaining basis vectors.
+    ## 4) If abln == 0 exit otherwise go to step 1) and repeat.
+
+    basis_tmp = basis
+
+    while not np.all(abln == 0):
+
+        ### Maximum possible Hamming weight of a given binary vector
+        hmng = 2 * n_qubits
+
+        idx = 0
+        for row in range(abln.shape[0]):
+            ### Find the basis vector e that commutes with most of the remaining basis vectors
+            hmng_tmp = np.sum(abln[row, :])
+            if hmng_tmp > 0 and hmng > hmng_tmp:
+                hmng = hmng_tmp
+                idx = row
+
+        ### Identify basis vectors that do not commute with e and eliminate them.
+        count = np.argwhere(abln[idx,:] == 1)
+        basis_tmp = np.delete(basis_tmp, count, axis=0)
+
+        ### Construct abln matrix for the next iteration.
+
+        aux = np.matmul(blnr_frm_mtrx, basis_tmp.T)
+
+        abln = np.zeros((basis_tmp.shape[0], basis_tmp.shape[0]), dtype=np.uint8)
+        for row in range(basis_tmp.shape[0]):
+            for column in range(basis_tmp.shape[0]):
+                for idx in range(2*n_qubits):
+                    abln[row, column] = (abln[row, column] + basis_tmp[row, idx] * aux[idx, column]) % 2
+
+    tau = basis_tmp
+
+    #### This step is not necessary. It transforms the generators of the symmetry group in such a way that the
+    #### removed qubits have the smallest/largest possbile identity numbers. A similar modification is made
+    #### at the "sigma_x selection" part of the algorithm below. The "smallest" case produces identical resutls
+    #### with those obtained using Qiskit, after taking into account that in Qiskit Slater determinants are
+    #### represented by strings of alpha orbitals followed by the beta ones.
+    idx = 0
+    lst = []
+    if qiskit_order:
+        _range = list(reversed(range(n_qubits, 2 * n_qubits)))
+    else:
+        _range = list(range(n_qubits, 2 * n_qubits))
+    for column in _range:
+        count = np.argwhere(tau[:, column] == 1)
+        if count.shape[0] == 1:
+            if count[0] not in lst:
+                lst.append(int(count[0]))
+                idx += 1
+        else:
+            for i in range(count.shape[0]):
+                if count[i] not in lst:
+                    lst.append(int(count[i]))
+                    for el in filter(lambda el: el not in count[i], count):
+                        tau[int(el), :] = np.bitwise_xor(tau[int(el), :], tau[int(count[i]), :])
+                    idx += 1
+                    break
+        if idx == tau.shape[0]:
+            break
+    ####
+
+    # 4) Construct unitary matrix that will transform Hamiltonian
+
+    ## Translate binary vectors back to Pauli strings to obtain the generators of the symmetry group
+    gnrtrs = []
+    for i in range(tau.shape[0]):
+        pauli = qf.Circuit()
+        for j in reversed(range(n_qubits)):
+            if tau[i, j] == 1 and tau[i, j + n_qubits] == 1:
+                pauli.add_gate(qf.gate('Y', n_qubits - j - 1))
+            elif tau[i, j] == 1:
+                pauli.add_gate(qf.gate('X', n_qubits - j - 1))
+            elif tau[i, j + n_qubits] == 1:
+                pauli.add_gate(qf.gate('Z', n_qubits - j - 1))
+        gnrtrs.append(pauli)
+
+    ## Find which sigma_x gate will be paired with which generator
+    sigma_x = np.zeros((tau.shape[0]), dtype=np.uint16)
+
+    if qiskit_order:
+        _range = list(range(n_qubits))
+    else:
+        _range = list(reversed(range(n_qubits)))
+    for i in _range:
+        if np.argwhere(tau[:,n_qubits + i] == 1).shape[0] == 1:
+            sigma_x[np.argwhere(tau[:,n_qubits + i] == 1)] = n_qubits - i - 1
+
+    ## Reorder sigma_x operators in descending order of qubit identity. Do the same with the generators for consistency.
+
+    reorder = np.argsort(sigma_x)
+    sigma_x = sigma_x[reorder][::-1]
+    gnrtrs = [gnrtrs[i] for i in reorder]
+
+    ## Construct individual unitary matrices
+    untrs = []
+
+    for idx, generator in enumerate(gnrtrs):
+        circ = qf.Circuit()
+        circ.add_gate(qf.gate('X', sigma_x[idx]))
+        oprtr = qf.QubitOperator()
+        oprtr.add_term(1/np.sqrt(2), generator)
+        oprtr.add_term(1/np.sqrt(2), circ)
+        untrs.append(oprtr)
+
+    ## Construct final unitary matrix
+    unitary = qf.QubitOperator()
+    unitary.add_op(untrs[0])
+    for op in untrs[1:]:
+        unitary.operator_product(op, True, True)
+
+    # 5) Compute the various signs corresponding to the eigenvalues of the sigma_x operators that will be removed
+
+    signs = list(product([1, -1], repeat=len(sigma_x)))
+
+    return gnrtrs, sigma_x, untrs, unitary, signs
+
+def qubit_tapering_oprtr(n_qubits, tapered_qubits, sign, operator, unitary):
+
+    """
+    This function uses the unitary matrix obtained using find_Z2_symmetries to transform a given operator.
+    After the unitary transformation, the resulting operator acts on the qubits to be tapered off by at most
+    a single sigma_x operator. The sigma_x gates acting on qubits to be tapered off are replaced by their
+    +/- 1 eigenvalues, which are provided by the user.
+
+    Arguments
+
+    n_qubits: integer
+        Initial number of qubits.
+
+    tapered_qubits: list of integers
+        The ID numbers of the qubits to be tapered off.
+
+    sign: list of +/- 1.
+        The desired sign structure corresponding to the eigenvalues of the sigma_x operators acting on
+        the qubits to be tapered off.
+
+    operator: QubitOperator
+        The operator that we wish to transform. For example, the qubit Hamiltonian or the UCC ansatz.
+
+    unitary: QubitOperator
+        The unitary operator that will perform the dersired transformation.
+    """
+
+    # Transform the given operator using the fact that the unitary matrix is also Hermitian
+
+    unitary_tmp = qf.QubitOperator()
+    unitary_tmp.add_op(unitary)
+    operator.operator_product(unitary_tmp, True, True)
+    unitary_tmp.operator_product(operator, True, True)
+    operator = unitary_tmp
+
+    # Create a QForte QubitOperator object that will store the tapered operator
+    operator_tapered = qf.QubitOperator()
+
+    coeff_tmp = []
+    for counter, term in enumerate(operator.terms()):
+        # Create circuit that will store the pauli string with gates corresponding to qubits to be tapered off removed
+        circ = qf.Circuit()
+        # List that will store the coefficients modified according to the sign structure provided by the user
+        coeff_tmp.append(term[0])
+        for pauli in term[1].gates():
+            if any(qubit == pauli.target() for qubit in tapered_qubits):
+                coeff_tmp[counter] *= sign[int(np.argwhere(tapered_qubits == pauli.target()))]
+            else:
+                # Adjust the qubit ID of a given gate based on the number of gates that were removed before it
+                idx = np.count_nonzero(pauli.target() > tapered_qubits)
+                target = pauli.target() - idx
+                gate = pauli.gate_id()
+                circ.add_gate(qf.gate(gate, target))
+
+        operator_tapered.add_term(term[0], circ)
+
+    # Replace the coefficients with the ones having the requested sign structure
+    operator_tapered.set_coeffs(coeff_tmp)
+    # Simplify the entire operator
+    operator_tapered.simplify(True)
+
+    return operator_tapered
+
+def qubit_tapering_ref(tapered_qubits, ref):
+
+    """
+    This function removes the designated qubits from a given reference.
+
+    Arguments
+
+    tapered_qubits: list of integers
+        The ID numbers of the qubits to be tapered off.
+
+    ref: list of integers
+        A bit string representing the reference Slater determinant.
+    """
+
+    for i in tapered_qubits:
+        del ref[i]
+
+    return ref

--- a/src/qforte/utils/qubit_tapering.py
+++ b/src/qforte/utils/qubit_tapering.py
@@ -5,8 +5,9 @@ Functions for performing qubit tapering based on the Z2 symmetries of the qubit 
 import qforte as qf
 import numpy as np
 from itertools import product
+from copy import deepcopy
 
-def find_Z2_symmetries(hamiltonian, qiskit_order = False):
+def find_Z2_symmetries(hamiltonian, taper_from_least = False):
     """
     This function computes the Z2 symmetries of the Hamiltonian, identifies the ID numbers of the qubits to
     be tapered off, provides the corresponding sign structures, and constructs the necessary unitary operators.
@@ -17,29 +18,45 @@ def find_Z2_symmetries(hamiltonian, qiskit_order = False):
     hamiltonian: QubitOperator
         The qubit Hamiltonian whose Z2 symmetries we want to find.
 
-    qiskit_order: bool
+    taper_from_least: bool
         If True, the qubits to be tapered off will have the smallest id numbers possible, as is done in Qiskit.
         If False, the qubits to be tapered off will have the largest id numbers possible. This is the default,
         since it leads to less operations once the qubits are removed.
+
+    Returns:
+
+    generators: list of QubitOperator objects
+        Qubit representation of set of independent generators of the symmetry group of the Hamiltonian.
+
+    sigma_x: list of integers
+        The indices of the sigma_x Pauli gates that each generator will be transformed to.
+        The indices coincide with the indices of the qubits to be tapered off.
+
+    unitaries: list of QubitOperator objects
+        The Clifford gates that transform each generator to a given sigma_x Pauli gate.
+
+    unitary: QubitOperator
+        The final Clifford gate that performs the desired similarity transformation.
+
+    signs: list of +/- 1 tuples
+        Each tuple corresponds to a different symmetry subspace of the Hamiltonian.
+        For each qubit to be tapered off, we can either be in the +1 or -1 subspace.
     """
 
     # The algorithm consists of the following steps:
-    # 1) Convert qubit Hamiltonian to binary matrix, called the parity check matrix E
+    # 1) Construct the parity check matrix E from a given qubit Hamiltonian
     # 2) Find the basis of the kernel of the parity check matrix, ker{E}
     # 3) Find maximal Abelian subgroup of the basis of ker{E}
     # 4) Construct unitary matrices that will be used in the qubit_tapering algorithm
     # 5) Compute the various signs corresponding to the eigenvalues of the sigma_x operators that will be removed
 
-    # 1) Convert qubit Hamiltonian to binary matrix
+    # 1) Construct the parity check matrix E from a given qubit Hamiltonian
 
-    ## Obtain number of qubits and number of Pauli strings contained in qubit Hamiltonian
     n_qubits = hamiltonian.num_qubits()
     n_strings = len(hamiltonian.terms())
 
-    ## Construct parity check matrix.
     ## The rows of the parity check matrix correspond to Pauli strings of the qubit Hamiltonian.
     ## The columns of the parity check matrix correspond to the Z_(n_qubits - 1), ..., Z_0, X_(n_qubits - 1), ..., X_0 Pauli gates.
-    ## For example, prt_chck_mtrx[i, n_qubits - 1] == 1 (0) designates the presence (absence) of the Z_0 Pauli gate in the ith Pauli string of the Hamiltonian.
     prt_chck_mtrx = np.zeros((n_strings, 2 * n_qubits), dtype=np.uint8)
     for i, (_, string) in enumerate(hamiltonian.terms()):
         for pauli in string.gates():
@@ -59,114 +76,106 @@ def find_Z2_symmetries(hamiltonian, qiskit_order = False):
 
     ## Find column echelon form (CEF) of augmented matix.
 
-    ### To speed up the process, we only work with the part of the parity check matrix that has not been transformed yet to CEF.
+    ### We only work with the columns of the parity check matrix that have not been transformed yet to CEF.
     ### This is controlled by the "idx" variable
     idx = 0
 
     for row in range(n_strings):
         ### Find a non-zero row
-        clmns_not_in_CEF = prt_chck_mtrx_aug[row,idx:]
-        if np.any(clmns_not_in_CEF):
-            ### Find positions of non-zero elements
-            nonzero_indices = np.argwhere(clmns_not_in_CEF)
-            column = int(nonzero_indices[0]) + idx
-            ### Swap columns to bring first non-zero element in this row immediately to the right of that of the previous row
-            prt_chck_mtrx_aug[:, [column , idx]] = prt_chck_mtrx_aug[:, [idx, column]]
-            ### Eliminate remaining non-zero elements in the submatrix
+        nonzero_indices = np.argwhere(prt_chck_mtrx_aug[row,idx:])
+        if nonzero_indices.shape[0] > 0:
+            column_to_be_CEFed = int(nonzero_indices[0]) + idx
+            ### Bring first non-zero element in this row immediately to the right of that of the previous row
+            prt_chck_mtrx_aug[:, [column_to_be_CEFed , idx]] = prt_chck_mtrx_aug[:, [idx, column_to_be_CEFed]]
+            ### Eliminate remaining non-zero row elements in the part of the parity check matrix that is not in CEF
             for i in range(1,nonzero_indices.shape[0]):
-                column2 = int(nonzero_indices[i]) + idx
-                prt_chck_mtrx_aug[:,column2] = np.bitwise_xor(prt_chck_mtrx_aug[:, idx], prt_chck_mtrx_aug[:,column2])
+                column_not_in_CEF = int(nonzero_indices[i]) + idx
+                prt_chck_mtrx_aug[:,column_not_in_CEF] = np.bitwise_xor(prt_chck_mtrx_aug[:, idx], prt_chck_mtrx_aug[:,column_not_in_CEF])
             ### decrease the number of columns that need to be checked
             idx += 1
 
     ## Find basis vectors of kernel by checking for zero columns in the CEF of the parity check matrix
 
-    dim = 0
+    dim = False
     basis = np.zeros((1, 2 * n_qubits), dtype=np.uint8)
-    for column in range(2 * n_qubits):
+    # The first idx columns are nonzero by construction
+    for column in range(idx, 2 * n_qubits):
         row = n_strings
         if not np.any(prt_chck_mtrx_aug[:row, column]):
-            if dim == 0:
-                basis = prt_chck_mtrx_aug[row:, column].reshape((1,2 * n_qubits))
-                dim += 1
+            new_basis_vector = prt_chck_mtrx_aug[row:, column].reshape((1,2 * n_qubits))
+            if dim is False:
+                basis = new_basis_vector
+                dim = True
             else:
-                basis = np.concatenate((basis, prt_chck_mtrx_aug[row:, column].reshape((1,2 * n_qubits))), axis=0)
+                basis = np.concatenate((basis, new_basis_vector), axis=0)
 
     # 3) Find maximal Abelian subgroup of the basis of ker{E}
     # This is done using the symplectic bilinear form B that the binary vector space is equipped with:
     # B(v,w) = v * B * w.T,
     # where v and w are binary vectors and B is the matrix of the bilinear form.
+    # B(v,w) = 0 means that v and w commute while B(v,w) = 1 means that they anticommute.
 
     ## Construct matrix of bilinear form.
 
-    top = np.concatenate((np.zeros((n_qubits, n_qubits), dtype=np.uint8), np.identity(n_qubits, dtype=np.uint8)), axis=1)
-    bottom = np.concatenate((np.identity(n_qubits, dtype=np.uint8), np.zeros((n_qubits, n_qubits), dtype=np.uint8)), axis=1)
-    blnr_frm_mtrx = np.concatenate((top, bottom), axis=0)
+    zero_matrix = np.zeros((n_qubits, n_qubits), dtype=np.uint8)
+    identity_matrix = np.identity(n_qubits, dtype=np.uint8)
+    blnr_frm_mtrx = np.block([
+        [zero_matrix    , identity_matrix],
+        [identity_matrix, zero_matrix    ]
+        ])
 
-    ## Construct abln matrix.
-    ## abln[i,j] contains the value of the bilinear form betweeen the ith and jth basis vectors of ker{E}
-    ## A "0"/"1" in the ith row and jth column of abln means that the Pauli strings
+    ## Construct abelian matrix.
+    ## abelian[i,j] contains the value of the bilinear form betweeen the ith and jth basis vectors of ker{E}
+    ## 0/1 in the ith row and jth column of abelian means that the Pauli strings
     ## associated with the ith and jth binary vectors commute/anticommute.
 
-    aux = np.matmul(blnr_frm_mtrx, basis.T)
-
-    abln = np.zeros((basis.shape[0], basis.shape[0]), dtype=np.uint8)
-    for row in range(basis.shape[0]):
-        for column in range(basis.shape[0]):
-            for idx in range(2*n_qubits):
-                abln[row, column] = (abln[row, column] + basis[row, idx] * aux[idx, column]) % 2
+    abelian = np.matmul(basis, np.matmul(blnr_frm_mtrx, basis.T))
+    abelian %= 2
 
     ## Find the maximal abelian subgroup iteratively. This is done as follows:
-    ## 1) Find non-zero row of abln with smallest Hamming weight.
+    ## 1) Find non-zero row of abelian with smallest Hamming weight.
     ##    The corresponding basis vector e commutes with most other basis vectors.
     ## 2) Find basis vectors that do not commute with e and remove them.
-    ## 3) Reconstruct abln matrix with remaining basis vectors.
-    ## 4) If abln == 0 exit otherwise go to step 1) and repeat.
+    ## 3) Reconstruct abelian matrix with remaining basis vectors.
+    ## 4) If abelian == 0 exit otherwise go to step 1) and repeat.
 
     basis_tmp = basis
 
-    while not np.all(abln == 0):
+    while not np.all(abelian == 0):
 
         ### Maximum possible Hamming weight of a given binary vector
         hmng = 2 * n_qubits
 
         idx = 0
-        for row in range(abln.shape[0]):
+        for row in range(abelian.shape[0]):
             ### Find the basis vector e that commutes with most of the remaining basis vectors
-            hmng_tmp = np.sum(abln[row, :])
+            hmng_tmp = np.sum(abelian[row, :])
             if hmng_tmp > 0 and hmng > hmng_tmp:
                 hmng = hmng_tmp
                 idx = row
 
         ### Identify basis vectors that do not commute with e and eliminate them.
-        nonzero_indices = np.argwhere(abln[idx,:])
+        nonzero_indices = np.argwhere(abelian[idx,:])
         basis_tmp = np.delete(basis_tmp, nonzero_indices, axis=0)
 
-        ### Construct abln matrix for the next iteration.
+        ### Construct abelian matrix for the next iteration.
 
-        aux = np.matmul(blnr_frm_mtrx, basis_tmp.T)
+        abelian = np.matmul(basis_tmp, np.matmul(blnr_frm_mtrx, basis_tmp.T))
+        abelian %= 2
 
-        abln = np.zeros((basis_tmp.shape[0], basis_tmp.shape[0]), dtype=np.uint8)
-        for row in range(basis_tmp.shape[0]):
-            for column in range(basis_tmp.shape[0]):
-                for idx in range(2*n_qubits):
-                    abln[row, column] = (abln[row, column] + basis_tmp[row, idx] * aux[idx, column]) % 2
+    generators_binary = basis_tmp
 
-    tau = basis_tmp
-
-    #### This step is not necessary. It transforms the generators of the symmetry group in such a way that the
-    #### removed qubits have the smallest/largest possbile identity numbers. A similar modification is made
-    #### at the "sigma_x selection" part of the algorithm below. The "smallest" case produces identical resutls
-    #### with those obtained using Qiskit, after taking into account that in Qiskit Slater determinants are
-    #### represented by strings of alpha orbitals followed by the beta ones.
+    ### This step is not necessary. It transforms the generators of the symmetry group in such a way that the
+    ### removed qubits have the smallest/largest possbile identity numbers. A similar modification is made
+    ### at the "sigma_x selection" part of the algorithm below.
     idx = 0
     lst = []
-    if qiskit_order:
+    if taper_from_least:
         _range = list(reversed(range(n_qubits, 2 * n_qubits)))
     else:
         _range = list(range(n_qubits, 2 * n_qubits))
     for column in _range:
-        nonzero_indices = np.argwhere(tau[:, column])
+        nonzero_indices = np.argwhere(generators_binary[:, column])
         if nonzero_indices.shape[0] == 1:
             if nonzero_indices[0] not in lst:
                 lst.append(int(nonzero_indices[0]))
@@ -176,71 +185,71 @@ def find_Z2_symmetries(hamiltonian, qiskit_order = False):
                 if nonzero_indices[i] not in lst:
                     lst.append(int(nonzero_indices[i]))
                     for el in filter(lambda el: el not in nonzero_indices[i], nonzero_indices):
-                        tau[int(el), :] = np.bitwise_xor(tau[int(el), :], tau[int(nonzero_indices[i]), :])
+                        generators_binary[int(el), :] = np.bitwise_xor(generators_binary[int(el), :], generators_binary[int(nonzero_indices[i]), :])
                     idx += 1
                     break
-        if idx == tau.shape[0]:
+        if idx == generators_binary.shape[0]:
             break
-    ####
+    ###
 
     # 4) Construct unitary matrix that will transform Hamiltonian
 
     ## Translate binary vectors back to Pauli strings to obtain the generators of the symmetry group
-    gnrtrs = []
-    for i in range(tau.shape[0]):
+    generators = []
+    for i in range(generators_binary.shape[0]):
         pauli = qf.Circuit()
         for j in reversed(range(n_qubits)):
-            if tau[i, j] != 0 or tau[i, j + n_qubits] != 0:
-                if tau[i, j] == 1 and tau[i, j + n_qubits] == 1:
+            if generators_binary[i, j] != 0 or generators_binary[i, j + n_qubits] != 0:
+                if generators_binary[i, j] == 1 and generators_binary[i, j + n_qubits] == 1:
                     gate_type = 'Y'
-                elif tau[i, j] == 1:
+                elif generators_binary[i, j] == 1:
                     gate_type = 'X'
-                elif tau[i, j + n_qubits] == 1:
+                elif generators_binary[i, j + n_qubits] == 1:
                     gate_type = 'Z'
                 pauli.add_gate(qf.gate(gate_type, n_qubits - j - 1))
-        gnrtrs.append(pauli)
+        generators.append(pauli)
 
     ## Find which sigma_x gate will be paired with which generator
-    sigma_x = np.zeros((tau.shape[0]), dtype=np.uint16)
+    sigma_x = np.zeros((generators_binary.shape[0]), dtype=np.uint16)
 
-    if qiskit_order:
+    if taper_from_least:
         _range = range(n_qubits)
     else:
         _range = reversed(range(n_qubits))
     for i in _range:
-        if np.argwhere(tau[:,n_qubits + i]).shape[0] == 1:
-            sigma_x[np.argwhere(tau[:,n_qubits + i])] = n_qubits - i - 1
+        if np.argwhere(generators_binary[:,n_qubits + i]).shape[0] == 1:
+            sigma_x[np.argwhere(generators_binary[:,n_qubits + i])] = n_qubits - i - 1
 
     ## Reorder sigma_x operators in descending order of qubit identity. Do the same with the generators for consistency.
 
     reorder = np.argsort(sigma_x)
     sigma_x = sigma_x[reorder][::-1]
-    gnrtrs = [gnrtrs[i] for i in reorder[::-1]]
+    generators = [generators[i] for i in reorder[::-1]]
 
     ## Construct individual unitary matrices
-    untrs = []
+    unitaries = []
 
-    for idx, generator in enumerate(gnrtrs):
+    for idx, generator in enumerate(generators):
         circ = qf.Circuit()
         circ.add_gate(qf.gate('X', sigma_x[idx]))
         oprtr = qf.QubitOperator()
         oprtr.add_term(1/np.sqrt(2), generator)
         oprtr.add_term(1/np.sqrt(2), circ)
-        untrs.append(oprtr)
+        unitaries.append(oprtr)
 
     ## Construct final unitary matrix
     unitary = qf.QubitOperator()
-    unitary.add_op(untrs[0])
-    for op in untrs[1:]:
+    unitary.add_op(unitaries[0])
+    for op in unitaries[1:]:
         unitary.operator_product(op, True, True)
 
     # 5) Compute the various signs corresponding to the eigenvalues of the sigma_x operators that will be removed
 
     signs = list(product([1, -1], repeat=len(sigma_x)))
 
-    return gnrtrs, sigma_x, untrs, unitary, signs
+    return generators, sigma_x, unitaries, unitary, signs
 
-def qubit_tapering_oprtr(tapered_qubits, sign, operator, unitary):
+def qubit_tapering_operator(tapered_qubits, sign, operator, unitary):
     """
     This function uses the unitary matrix obtained using find_Z2_symmetries to transform a given operator.
     After the unitary transformation, the resulting operator acts on the qubits to be tapered off by at most
@@ -250,27 +259,36 @@ def qubit_tapering_oprtr(tapered_qubits, sign, operator, unitary):
     Arguments
 
     tapered_qubits: list of integers
-        The ID numbers of the qubits to be tapered off.
+        The indices of the qubits to be tapered off.
 
-    sign: list of +/- 1.
-        The desired sign structure corresponding to the eigenvalues of the sigma_x operators acting on
-        the qubits to be tapered off.
+    sign: list of +/- 1 of length len(tapered_qubits).
+        Specifies the symmetry subspace of the Hamiltonian that we are interested in.
+        For each qubit to be tapered off, we can either be in the +1 or -1 subspace.
 
     operator: QubitOperator
-        The operator that we wish to transform. For example, the qubit Hamiltonian or the UCC ansatz.
+        The operator that we wish to transform. For example, the qubit Hamiltonian or the UCC wave operator.
 
     unitary: QubitOperator
         The unitary operator that will perform the dersired transformation.
+
+    Returns
+
+    operator_tapered: QubitOperator
+        The tapered operator.
     """
+
+    # Validating 'sign' argument
+
+    if not all(i == 1 or i == -1 for i in sign):
+        raise ValueError('The signs should be either 1 or -1!')
+    if not len(sign) == len(tapered_qubits):
+        raise ValueError('There should be as many signs as the number of tapered qubits!')
 
     # Similarity transform the given operator using the fact that the unitary matrix is also Hermitian
 
-    ## This is necessary; otherwise later on we would be modifying the "unitary" object directly, which we do not want to do
+    ## Create copies of these operators to prevent changing the original values
     unitary_tmp = qf.QubitOperator()
     unitary_tmp.add_op(unitary)
-
-    ## This is necessary; if we do not do this, when transforming the Hamiltonian we would be changing the "hamiltonian"
-    ## attribute of the Molecule class to nonsense.
     operator_tmp = qf.QubitOperator()
     operator_tmp.add_op(operator)
 
@@ -282,40 +300,46 @@ def qubit_tapering_oprtr(tapered_qubits, sign, operator, unitary):
     operator_tapered = qf.QubitOperator()
 
     for i, (coeff, circuit) in enumerate(operator_tmp.terms()):
-        # Create circuit that will store the pauli string with gates corresponding to qubits to be tapered off removed
-        circ = qf.Circuit()
+        tapered_circuit = qf.Circuit()
         # List that will store the coefficients modified according to the sign structure provided by the user
         for pauli in circuit.gates():
             if any(qubit == pauli.target() for qubit in tapered_qubits):
                 coeff *= sign[int(np.argwhere(tapered_qubits == pauli.target()))]
             else:
-                # Adjust the qubit ID of a given gate based on the number of gates that were removed before it
+                # Adjust gate targets to account for tapered qubits
                 idx = np.count_nonzero(pauli.target() > tapered_qubits)
                 target = pauli.target() - idx
                 gate = pauli.gate_id()
-                circ.add_gate(qf.gate(gate, target))
+                tapered_circuit.add_gate(qf.gate(gate, target))
 
-        operator_tapered.add_term(coeff, circ)
+        operator_tapered.add_term(coeff, tapered_circuit)
 
-    # Simplify the entire operator
     operator_tapered.simplify(True)
 
     return operator_tapered
 
-def qubit_tapering_ref(tapered_qubits, ref):
+def taper_reference(tapered_qubits, ref):
     """
-    This function removes the designated qubits from a given reference.
+    This function removes the designated qubits from a given reference, ref.
 
-    Arguments
+    Arguments:
 
     tapered_qubits: list of integers
-        The ID numbers of the qubits to be tapered off.
+        The indices of the qubits to be tapered off.
 
     ref: list of integers
-        A bit string representing the reference Slater determinant.
+        A bit string representing the reference qubit state.
+
+    Returns:
+
+    ref_tapered: list of integers
+        A bit string representing the tapered reference qubit state.
     """
 
-    for i in tapered_qubits:
-        del ref[i]
+    ref_tapered = deepcopy(ref)
 
-    return ref
+    # WARNING: The code assumes that the tapered_qubits list is in descending order.
+    for i in tapered_qubits:
+        del ref_tapered[i]
+
+    return ref_tapered

--- a/src/qforte/utils/qubit_tapering.py
+++ b/src/qforte/utils/qubit_tapering.py
@@ -276,12 +276,10 @@ def Symplectic_Gram_Schmidt_Orthogonalization(basis, commute):
                         processed.add(pauli_2)
                         for pauli in range(SGSO_basis.shape[0]):
                             if pauli not in processed:
-                                if SGSO_commute[pauli, pauli_1] and SGSO_commute[pauli, pauli_2]:
-                                    SGSO_basis[pauli] ^= SGSO_basis[pauli_1] ^ SGSO_basis[pauli_2]
-                                elif SGSO_commute[pauli, pauli_1] and not SGSO_commute[pauli, pauli_2]:
-                                    SGSO_basis[pauli] ^= SGSO_basis[pauli_2]
-                                elif not SGSO_commute[pauli, pauli_1] and SGSO_commute[pauli, pauli_2]:
+                                if SGSO_commute[pauli, pauli_2]:
                                     SGSO_basis[pauli] ^= SGSO_basis[pauli_1]
+                                if SGSO_commute[pauli, pauli_1]:
+                                    SGSO_basis[pauli] ^= SGSO_basis[pauli_2]
                         break
 
                 SGSO_commute = find_commutation_matrix(SGSO_basis)

--- a/tests/test_qubit_tapering.py
+++ b/tests/test_qubit_tapering.py
@@ -11,16 +11,17 @@ class TestQubitTapering:
         ###          alternating alpha/beta spin orbitals. In Qiskit, all alpha spin orbitals
         ###          are placed before the beta ones.
 
-        generators_from_qiskit = ('[[Z13 Z10 Z8 Z7 Z5 Z2 Z0], ' +
+        generators_from_qiskit = ('[[Z7 Z6], ' +
+                                   '[Z13 Z12 Z5 Z4], ' +
                                    '[Z13 Z11 Z9 Z7 Z5 Z3 Z1], ' +
-                                   '[Z13 Z12 Z5 Z4], [Z7 Z6]]')
+                                   '[Z13 Z10 Z8 Z7 Z5 Z2 Z0]]')
 
         sigmas_from_qiskit = '[6 4 1 0]'
 
-        unitaries_from_qiskit = ('[+0.707107[Z13 Z10 Z8 Z7 Z5 Z2 Z0]\n+0.707107[X6], ' +
-                                  '+0.707107[Z13 Z11 Z9 Z7 Z5 Z3 Z1]\n+0.707107[X4], ' +
-                                  '+0.707107[Z13 Z12 Z5 Z4]\n+0.707107[X1], ' +
-                                  '+0.707107[Z7 Z6]\n+0.707107[X0]]')
+        unitaries_from_qiskit = ('[+0.707107[Z7 Z6]\n+0.707107[X6], ' +
+                                  '+0.707107[Z13 Z12 Z5 Z4]\n+0.707107[X4], ' +
+                                  '+0.707107[Z13 Z11 Z9 Z7 Z5 Z3 Z1]\n+0.707107[X1], ' +
+                                  '+0.707107[Z13 Z10 Z8 Z7 Z5 Z2 Z0]\n+0.707107[X0]]')
 
         sign_from_qiskit = ('[(1, 1, 1, 1), ' +
                              '(1, 1, 1, -1), ' +

--- a/tests/test_qubit_tapering.py
+++ b/tests/test_qubit_tapering.py
@@ -1,0 +1,57 @@
+from qforte import system_factory, find_Z2_symmetries
+
+class TestQubitTapering:
+
+    def test_find_z2_symmetries(self):
+
+        ### WARNING: This test is based on comparing the qubit tapering results of QForte with
+        ###          those of Qiskit. To be able to make such comparisons, one needs to take
+        ###          into account the different conventions in representing Slater determinants
+        ###          between the two codes. In QForte, Slater determinants are represented by
+        ###          alternating alpha/beta spin orbitals. In Qiskit, all alpha spin orbitals
+        ###          are placed before the beta ones.
+
+        generators_from_qiskit = ('[[Z13 Z10 Z8 Z7 Z5 Z2 Z0], ' +
+                                   '[Z13 Z11 Z9 Z7 Z5 Z3 Z1], ' +
+                                   '[Z13 Z12 Z5 Z4], [Z7 Z6]]')
+
+        sigmas_from_qiskit = '[6 4 1 0]'
+
+        unitaries_from_qiskit = ('[+0.707107[Z13 Z10 Z8 Z7 Z5 Z2 Z0]\n+0.707107[X6], ' +
+                                  '+0.707107[Z13 Z11 Z9 Z7 Z5 Z3 Z1]\n+0.707107[X4], ' +
+                                  '+0.707107[Z13 Z12 Z5 Z4]\n+0.707107[X1], ' +
+                                  '+0.707107[Z7 Z6]\n+0.707107[X0]]')
+
+        sign_from_qiskit = ('[(1, 1, 1, 1), ' +
+                             '(1, 1, 1, -1), ' +
+                             '(1, 1, -1, 1), ' +
+                             '(1, 1, -1, -1), ' +
+                             '(1, -1, 1, 1), ' +
+                             '(1, -1, 1, -1), ' +
+                             '(1, -1, -1, 1), ' +
+                             '(1, -1, -1, -1), ' +
+                             '(-1, 1, 1, 1), ' +
+                             '(-1, 1, 1, -1), ' +
+                             '(-1, 1, -1, 1), ' +
+                             '(-1, 1, -1, -1), ' +
+                             '(-1, -1, 1, 1), ' +
+                             '(-1, -1, 1, -1), ' +
+                             '(-1, -1, -1, 1), ' +
+                             '(-1, -1, -1, -1)]')
+
+        to_angs = 0.529177210903
+
+        mol = system_factory(system_type = 'molecule',
+                                         build_type = 'psi4',
+                                         basis='sto-3g',
+                                         mol_geometry = [('O', (0, 0, -0.013500 * to_angs)),
+                                                         ('H', (0, 2.2728945 * to_angs, -1.588347 * to_angs)),
+                                                         ('H', (0, -2.2728945 * to_angs, -1.588347 * to_angs))],
+                                         symmetry = 'c2v')
+
+        generators, sigmas, unitaries, unitary, sign = find_Z2_symmetries(mol.hamiltonian, True)
+
+        assert str(generators) == generators_from_qiskit
+        assert str(sigmas) == sigmas_from_qiskit
+        assert str(unitaries) == unitaries_from_qiskit
+        assert str(sign) == sign_from_qiskit

--- a/tests/test_qubit_tapering.py
+++ b/tests/test_qubit_tapering.py
@@ -1,4 +1,4 @@
-from qforte import system_factory, find_Z2_symmetries
+from qforte import system_factory, QubitOperator, find_Z2_symmetries, qubit_tapering_oprtr
 
 class TestQubitTapering:
 
@@ -50,9 +50,15 @@ class TestQubitTapering:
                                                          ('H', (0, -2.2728945 * to_angs, -1.588347 * to_angs))],
                                          symmetry = 'c2v')
 
+        orig_ham = QubitOperator()
+        orig_ham.add_op(mol.hamiltonian)
+
         generators, sigmas, unitaries, unitary, sign = find_Z2_symmetries(mol.hamiltonian, True)
+
+        tapered_ham = qubit_tapering_oprtr(sigmas, sign[0], mol.hamiltonian, unitary)
 
         assert str(generators) == generators_from_qiskit
         assert str(sigmas) == sigmas_from_qiskit
         assert str(unitaries) == unitaries_from_qiskit
         assert str(sign) == sign_from_qiskit
+        assert str(orig_ham) == str(mol.hamiltonian)

--- a/tests/test_qubit_tapering.py
+++ b/tests/test_qubit_tapering.py
@@ -1,4 +1,4 @@
-from qforte import system_factory, QubitOperator, find_Z2_symmetries, qubit_tapering_oprtr
+from qforte import system_factory, QubitOperator, find_Z2_symmetries, qubit_tapering_operator
 
 class TestQubitTapering:
 
@@ -55,7 +55,7 @@ class TestQubitTapering:
 
         generators, sigmas, unitaries, unitary, sign = find_Z2_symmetries(mol.hamiltonian, True)
 
-        tapered_ham = qubit_tapering_oprtr(sigmas, sign[0], mol.hamiltonian, unitary)
+        tapered_ham = qubit_tapering_operator(sigmas, sign[0], mol.hamiltonian, unitary)
 
         assert str(generators) == generators_from_qiskit
         assert str(sigmas) == sigmas_from_qiskit

--- a/tests/test_qubit_tapering.py
+++ b/tests/test_qubit_tapering.py
@@ -1,4 +1,4 @@
-from qforte import system_factory, QubitOperator, find_Z2_symmetries, qubit_tapering_operator
+from qforte import system_factory, QubitOperator, find_Z2_symmetries, taper_operator
 
 class TestQubitTapering:
 
@@ -23,23 +23,6 @@ class TestQubitTapering:
                                   '+0.707107[Z13 Z11 Z9 Z7 Z5 Z3 Z1]\n+0.707107[X1], ' +
                                   '+0.707107[Z13 Z10 Z8 Z7 Z5 Z2 Z0]\n+0.707107[X0]]')
 
-        sign_from_qiskit = ('[(1, 1, 1, 1), ' +
-                             '(1, 1, 1, -1), ' +
-                             '(1, 1, -1, 1), ' +
-                             '(1, 1, -1, -1), ' +
-                             '(1, -1, 1, 1), ' +
-                             '(1, -1, 1, -1), ' +
-                             '(1, -1, -1, 1), ' +
-                             '(1, -1, -1, -1), ' +
-                             '(-1, 1, 1, 1), ' +
-                             '(-1, 1, 1, -1), ' +
-                             '(-1, 1, -1, 1), ' +
-                             '(-1, 1, -1, -1), ' +
-                             '(-1, -1, 1, 1), ' +
-                             '(-1, -1, 1, -1), ' +
-                             '(-1, -1, -1, 1), ' +
-                             '(-1, -1, -1, -1)]')
-
         to_angs = 0.529177210903
 
         mol = system_factory(system_type = 'molecule',
@@ -53,12 +36,12 @@ class TestQubitTapering:
         orig_ham = QubitOperator()
         orig_ham.add_op(mol.hamiltonian)
 
-        generators, sigmas, unitaries, unitary, sign = find_Z2_symmetries(mol.hamiltonian, True)
+        generators, sigmas, unitaries, unitary = find_Z2_symmetries(mol.hamiltonian, True, True)
 
-        tapered_ham = qubit_tapering_operator(sigmas, sign[0], mol.hamiltonian, unitary)
+        sign = [1, 1, 1, 1]
+        tapered_ham = taper_operator(sigmas, sign, mol.hamiltonian, unitary)
 
         assert str(generators) == generators_from_qiskit
         assert str(sigmas) == sigmas_from_qiskit
         assert str(unitaries) == unitaries_from_qiskit
-        assert str(sign) == sign_from_qiskit
         assert str(orig_ham) == str(mol.hamiltonian)


### PR DESCRIPTION
## Description
This is the first step toward implementing qubit tapering in QForte. The new functions can find the Z2 symmetries of the Hamiltonian of interest, compute the Clifford gates, and taper off qubits from a given qubit operator and reference state.

The new test_qubit_tapering.py file checks that the symmetries found by QForte and Qiskit for H2O/STO-3G are identical. Once additional functionalities pertaining to qubit tapering become available, more tests will be added to this file.

The next step will be to interface these functions with the existing algorithms in QForte, starting, for example, with UCCNVQE.

## User Notes
- [x] Features added

## Checklist
- [x] Added/updated tests of new features
- [x] Documented source code
- [x] All tests passed successfully
- [x] Ready to go!
