### PR TITLE
Move UCC to Qubit Space

### DIFF
--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -64,7 +64,7 @@ class UCC:
             self._orb_e.append(ei)
 
     def get_res_over_mpdenom(self, residuals):
-        """This function returns a vector given by the residuals dividied by the
+        """This function returns a vector given by the residuals divided by the
         respective Moller Plesset denominators.
 
         Parameters

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -50,8 +50,8 @@ class UCCPQE(PQE, UCC):
         if not hasattr(self, '_pool_type'):
             raise NotImplementedError('Concrete UCCPQE class must define self._pool_type attribute.')
 
-        if not hasattr(self, '_pool_obj'):
-            raise NotImplementedError('Concrete UCCPQE class must define self._pool_obj attribute.')
+        if not hasattr(self, '_qubit_pool'):
+            raise NotImplementedError('Concrete UCCPQE class must define self._qubit_pool attribute.')
 
     #TODO: consider moving functions from uccnpqe or spqe into this class to
     #      to prevent duplication of code

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -76,12 +76,6 @@ class UCCVQE(VQE, UCC):
     def get_num_commut_measurements(self):
         pass
 
-    def fill_commutator_pool(self):
-        print('\n\n==> Building commutator pool for gradient measurement.')
-        self._commutator_pool = self._pool_obj.get_qubit_op_pool()
-        self._commutator_pool.join_as_commutator(self._qb_ham)
-        print('==> Commutator pool construction complete.')
-
     def measure_operators(self, operators, Ucirc, idxs=[]):
         """
         Parameters

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -92,12 +92,13 @@ PYBIND11_MODULE(qforte, m) {
 
     py::class_<QubitOpPool>(m, "QubitOpPool")
         .def(py::init<>())
-        .def("add", &QubitOpPool::add_term)
-        .def("add_term", &QubitOpPool::add_term)
+        .def("add", &QubitOpPool::add_term, "coeff"_a, "operator"_a, "description"_a = "")
+        .def("add_term", &QubitOpPool::add_term, "coeff"_a, "operator"_a, "description"_a = "")
         .def("set_coeffs", &QubitOpPool::set_coeffs)
         .def("set_op_coeffs", &QubitOpPool::set_op_coeffs)
         .def("set_terms", &QubitOpPool::set_terms)
         .def("terms", &QubitOpPool::terms)
+        .def("get_qubit_operator", &QubitOpPool::get_qubit_operator, "order_type"_a, "combine_like_terms"_a = true)
         .def("join_op_from_right_lazy", &QubitOpPool::join_op_from_right_lazy)
         .def("join_op_from_right", &QubitOpPool::join_op_from_right)
         .def("join_op_from_left", &QubitOpPool::join_op_from_left)
@@ -105,6 +106,10 @@ PYBIND11_MODULE(qforte, m) {
         .def("square", &QubitOpPool::square)
         .def("fill_pool", &QubitOpPool::fill_pool)
         .def("str", &QubitOpPool::str)
+        .def("__getitem__", [](const QubitOpPool &pool, size_t i) { return pool.terms()[i]; })
+        .def("__iter__", [](const QubitOpPool &pool) { return py::make_iterator(pool.terms()); },
+            py::keep_alive<0, 1>())
+        .def("__len__", [](const QubitOpPool &pool) { return pool.terms().size(); })
         .def("__str__", &QubitOpPool::str)
         .def("__repr__", &QubitOpPool::str);
 

--- a/src/qforte/circuit.h
+++ b/src/qforte/circuit.h
@@ -52,9 +52,9 @@ class Circuit {
     /// Return a vector of string representing this circuit.
     std::string str() const;
 
-    /// Return the number of qubits pertaining to this circuit. Note this is
-    /// not the numebr of unique qubits but the minimum number of qubits needed
-    /// to execute the circuit. For example the circut [X_0 Y_4 X_8] would requre
+    /// Return the number of qubits pertaining to this circuit. This is not
+    /// the number of unique qubits but the minimum number of qubits needed to
+    /// execute the circuit. For example the circuit [X_0 Y_4 X_8] requires
     /// nine qubits.    
     size_t num_qubits() const;
 

--- a/src/qforte/computer.h
+++ b/src/qforte/computer.h
@@ -73,7 +73,7 @@ class Computer {
     std::vector<std::complex<double>> direct_idxd_oppl_exp_val(const QubitOpPool& qopl, const std::vector<int>& idxs);
 
     /// measure expectation value of all operators in an operator pool, where
-    /// the operator coefficents have been multipiled by mults
+    /// the operator coefficients have been multiplied by mults
     std::vector<std::complex<double>> direct_oppl_exp_val_w_mults(
         const QubitOpPool& qopl,
         const std::vector<std::complex<double>>& mults);

--- a/src/qforte/computer.h
+++ b/src/qforte/computer.h
@@ -49,7 +49,7 @@ class Computer {
     void apply_gate(const Gate& qg);
 
     /// apply a constant to the quantum computer (WARNING, this operation
-    /// is not physical as it does not represent a unitary opperation). Only
+    /// is not physical as it does not represent a unitary operation). Only
     /// Exists for 'fast' version of the algorithm for efficiency reasons
     void apply_constant(const std::complex<double> a);
 
@@ -72,8 +72,8 @@ class Computer {
     /// measure expectation value for specific operators in an operator pool
     std::vector<std::complex<double>> direct_idxd_oppl_exp_val(const QubitOpPool& qopl, const std::vector<int>& idxs);
 
-    /// measure expectaion value of all operators in an operator pool, where the
-    /// operator coefficents have been multipild by mults
+    /// measure expectation value of all operators in an operator pool, where
+    /// the operator coefficents have been multipiled by mults
     std::vector<std::complex<double>> direct_oppl_exp_val_w_mults(
         const QubitOpPool& qopl,
         const std::vector<std::complex<double>>& mults);

--- a/src/qforte/qubit_op_pool.cc
+++ b/src/qforte/qubit_op_pool.cc
@@ -69,7 +69,7 @@ QubitOperator QubitOpPool::get_qubit_operator(const std::string& order_type, boo
             parent.add_op(child);
         }
     } else {
-        throw std::invalid_argument( "Invalid order_type specified.");
+        throw std::invalid_argument( "Invalid order_type specified. Allowed values are unique_lex and commuting_grp_lex.");
     }
     return parent;
 }

--- a/src/qforte/qubit_op_pool.h
+++ b/src/qforte/qubit_op_pool.h
@@ -20,7 +20,7 @@ class QubitOpPool {
     /// set all the terms of the QubitOperator from a vector of QubitOperators
     void set_terms(std::vector<std::pair<std::complex<double>, QubitOperator>>& new_terms);
 
-    /// add one set of anihilators and/or creators to the second quantized operator pool
+    /// Add a QubitOperator, and optionally a description
     void add_term(std::complex<double> coeff, const QubitOperator& q_op, const std::string& str = "");
 
     /// sets the operator pool coefficeints

--- a/src/qforte/qubit_op_pool.h
+++ b/src/qforte/qubit_op_pool.h
@@ -21,7 +21,7 @@ class QubitOpPool {
     void set_terms(std::vector<std::pair<std::complex<double>, QubitOperator>>& new_terms);
 
     /// add one set of anihilators and/or creators to the second quantized operator pool
-    void add_term(std::complex<double> coeff, const QubitOperator& q_op );
+    void add_term(std::complex<double> coeff, const QubitOperator& q_op, const std::string& str = "");
 
     /// sets the operator pool coefficeints
     void set_coeffs(const std::vector<std::complex<double>>& new_coeffs);
@@ -34,6 +34,9 @@ class QubitOpPool {
 
     /// return a vector of QubitOperators multiplied by thier coefficients
     const std::vector<std::pair< std::complex<double>, QubitOperator>>& operator_terms() const;
+
+    /// Convert a pool into an operator
+    QubitOperator get_qubit_operator(const std::string& order_type, bool combine_like_terms=true);
 
     /// join an operator to all terms from the right as (i.e. term -> term*Op)
     /// without simplifying
@@ -57,16 +60,20 @@ class QubitOpPool {
     /// return a vector of strings representing this quantum operator pool
     std::string str() const;
 
+    const std::string& get_description(size_t i) { return descriptions_[i] ;} ;
+
   private:
     /// the list of sq operators in the pool
     std::vector<std::pair<std::complex<double>, QubitOperator>> terms_;
+
+    /// descriptions of each operator in the pool. optional
+    std::vector<std::string> descriptions_;
 
     /// returns a string representing I in base 4
     std::string to_base4(int I);
 
     /// fixes the number of preceding zeros in I_str based on nqb
     std::string pauli_idx_str(std::string I_str, int nqb);
-
 };
 
 #endif // _qubit_op_pool_h_

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -55,7 +55,7 @@ QubitOpPool SQOpPool::get_qubit_op_pool(){
     for (auto& term : terms_) {
         // QubitOperator a = term.second.jw_transform();
         // a.mult_coeffs(term.first);
-        A.add_term(term.first, term.second.jw_transform());
+        A.add_term(term.first, term.second.jw_transform(), term.second.str());
     }
     return A;
 }
@@ -81,7 +81,6 @@ QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool c
             child.simplify(combine_like_terms=combine_like_terms);
             child.order_terms();
             parent.add_op(child);
-
         }
     } else {
         throw std::invalid_argument( "Invalid order_type specified.");

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -49,9 +49,6 @@ class ADAPTVQE(UCCVQE):
         The gradient norm threshold to determine when the ADAPT-VQE
         algorithm has converged.
 
-    _commutator_pool : [QubitOpPool]
-        The list of [H, X] to be measured
-
     _converged : bool
         Whether or not the ADAPT-VQE has converged according to the gradient-norm
         threshold.
@@ -100,7 +97,6 @@ class ADAPTVQE(UCCVQE):
         self._grad_norms = []
         self._tops = []
         self._tamps = []
-        self._commutator_pool = []
         self._converged = 0
 
         self._n_ham_measurements = 0

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -121,12 +121,6 @@ class ADAPTVQE(UCCVQE):
 
         self.fill_pool()
 
-        if self._verbose:
-            print('\n\n-------------------------------------')
-            print('   Second Quantized Operator Pool')
-            print('-------------------------------------')
-            print(self._pool_obj.str())
-
         avqe_iter = 0
         hit_maxiter = 0
 
@@ -239,7 +233,7 @@ class ADAPTVQE(UCCVQE):
         print('\n\n                ==> ADAPT-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final ADAPT-VQE Energy:                     ', round(self._Egs, 10))
-        print('Number of operators in pool:                 ', len(self._pool_obj))
+        print('Number of operators in pool:                 ', len(self._qubit_pool))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Total number of Hamiltonian measurements:    ', self.get_num_ham_measurements())
         print('Total number of commutator measurements:      ', self.get_num_commut_measurements())
@@ -397,7 +391,7 @@ class ADAPTVQE(UCCVQE):
         return self._n_ham_measurements
 
     def get_num_commut_measurements(self):
-        self._n_commut_measurements += len(self._tamps) * len(self._pool_obj)
+        self._n_commut_measurements += len(self._tamps) * len(self._qubit_pool)
 
         if self._use_analytic_grad:
             for m, res in enumerate(self._results):

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -20,7 +20,7 @@ class SPQE(UCCPQE):
     In SPQE, a batch of important particle-hole operators
     :math:`\{ e^{t_\mu (\hat{\\tau}_\mu - \hat{\\tau}_\mu^\dagger )} \}` are
     added at each macro-iteration :math:`n` to the SPQE unitary :math:`\hat{U}(\mathbf{t})`,
-    wile all current parameters are optemized using the quasi-Newton PQE update
+    while all current parameters are optimized using the quasi-Newton PQE update
     with micro-iterations :math:`k`.
 
     In our selection approach we consider a (normalized) quantum state of the form

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -18,7 +18,6 @@ from qforte.helper.printing import matprint
 
 import numpy as np
 from scipy.linalg import lstsq
-from collections import Counter
 
 class UCCNPQE(UCCPQE):
     """
@@ -157,14 +156,6 @@ class UCCNPQE(UCCPQE):
     def solve(self):
         self.diis_solve(self.get_residual_vector)
 
-    def fill_excited_dets(self):
-
-        reference_state = qforte.QubitBasis(self._nqb)
-        for k, occ in enumerate(self._ref):
-            reference_state.set_bit(k, occ)
-
-        self._excited_dets = [operator_to_determinant(qubit_operator, reference_state) for _, qubit_operator in self._qubit_pool]
-
     def get_residual_vector(self, trial_amps):
         """Returns the residual vector with elements pertaining to all operators
         in the ansatz circuit.
@@ -215,3 +206,4 @@ class UCCNPQE(UCCPQE):
             self._tamps.append(0.0)
 
 UCCNPQE.diis_solve = optimizer.diis_solve
+UCCNPQE.fill_excited_dets = fill_excited_dets

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -262,11 +262,6 @@ class UCCNVQE(UCCVQE):
         #     return 0
         return 0
 
-    def fill_excited_dets(self):
-        reference_state = qforte.QubitBasis(self._nqb)
-        for k, occ in enumerate(self._ref):
-            reference_state.set_bit(k, occ)
-
-        self._excited_dets = [operator_to_determinant(qubit_operator, reference_state) for _, qubit_operator in self._qubit_pool]
-
 UCCNVQE.diis_solve = optimizer.diis_solve
+UCCNVQE.fill_excited_dets = fill_excited_dets
+

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -55,7 +55,6 @@ class UCCNVQE(UCCVQE):
 
         self._tops = []
         self._tamps = []
-        self._conmutator_pool = []
         self._converged = 0
 
         self._n_classical_params = 0

--- a/src/qforte/utils/transforms.py
+++ b/src/qforte/utils/transforms.py
@@ -332,7 +332,7 @@ def pauli_condense(pauli_op):
 def operator_to_determinant(operator: qforte.QubitOperator, reference: qforte.QubitBasis) -> tuple[int, complex]:
 
     """
-    Maps an QubitOperator and a QubitBasis to the index of the basis state
+    Maps a QubitOperator and a QubitBasis to the index of the basis state
     that operator sends reference to, as well as the phase factor.
 
     Will raise an error if operator does not send reference to a single basis state.
@@ -364,3 +364,9 @@ def operator_to_determinant(operator: qforte.QubitOperator, reference: qforte.Qu
     else:
         raise Exception(f"{operator} does not send the reference to a Pauli string.")
 
+def fill_excited_dets(self):
+    reference_state = qforte.QubitBasis(self._nqb)
+    for k, occ in enumerate(self._ref):
+        reference_state.set_bit(k, occ)
+
+    self._excited_dets = [operator_to_determinant(qubit_operator, reference_state) for _, qubit_operator in self._qubit_pool]

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -150,4 +150,4 @@ class TestPointGroupSymmetry():
 
             assert Egs == approx(Efci, abs=1.0e-10)
 
-            assert len(alg._pool_obj) == t_ops[count]
+            assert len(alg._qubit_pool) == t_ops[count]


### PR DESCRIPTION
## Description
Closes #127. `AnsatzAlgorithm._pool_obj` is banished to oblivion in favor of `AnastzAlgorithm._qubit_pool`.

This is major enough interest that I'm notifying @fevangelista. Review not required, but would be appreciated.

## User Notes
- [x] The `_pool_obj` is no longer on the `AnsatzAlgorithm` and has been replaced with `_qubit_pool`
- [x] Pybinding a few features of the `QubitOpPool`
- [x] `QubitOpPool` now has a description field, if you want to specify what these generators mean in some other space, i.e., fermion space
- [x]  `QubitOpPool::get_qubit_operator` added. This is rough and will need to be re-analyzer later.

## Checklist
- [x] Docstrings updated, where appropriate
- [x] Ready to go!
