### PR TITLE
QPE Bugfix I

### DIFF
--- a/src/qforte/qpea/qpe.py
+++ b/src/qforte/qpea/qpe.py
@@ -15,11 +15,17 @@ from scipy import stats
 
 class QPE(Algorithm):
     def run(self,
-            guess_energy,
+            guess_energy: float,
             t = 1.0,
             nruns = 20,
             success_prob = 0.5,
             num_precise_bits = 4):
+        """
+        guess_energy : A guess for the eigenvalue of the eigenspace with which |0>^(n)
+            has greatest overlap. You should be confident the ground state is within
+        t : A scaling parameter that controls the precision of the computation. You should
+            confident that the eigenvalue of interest is within +/- t of the guess energy.
+        """
 
         # float: evolution times
         self._t = t

--- a/src/qforte/utils/trotterization.py
+++ b/src/qforte/utils/trotterization.py
@@ -10,7 +10,7 @@ import copy
 def trotterize(operator, factor=1.0, trotter_number=1, trotter_order=1):
 
     """
-    returns a circuit equivilant to an exponentiated QubitOperator
+    returns a circuit equivalent to an exponentiated QubitOperator
 
     :param operator: (QubitOperator) the operator or state preparation ansatz
     (represented as a sum of pauli terms) to be exponentiated
@@ -19,18 +19,18 @@ def trotterize(operator, factor=1.0, trotter_number=1, trotter_order=1):
     is the exponent (N) for to product of single term
     exponentals e^A ~ ( Product_i(e^(A_i/N)) )^N
 
-    :param trotter_number: (int) the order of the troterization approximation, can be 1 or 2
+    :param trotter_number: (int) the order of the trotterization approximation, can be 1 or 2
     """
 
     total_phase = 1.0
-    troterized_operator = qforte.Circuit()
+    trotterized_operator = qforte.Circuit()
 
     if (trotter_number == 1) and (trotter_order == 1):
         #loop over terms in operator
         for term in operator.terms():
             term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1])
             for gate in term_generator.gates():
-                troterized_operator.add(gate)
+                trotterized_operator.add(gate)
             total_phase *= phase
 
 
@@ -50,12 +50,12 @@ def trotterize(operator, factor=1.0, trotter_number=1, trotter_order=1):
                 troterized_operator.add(gate)
             total_phase *= phase
 
-    return (troterized_operator, total_phase)
+    return (trotterized_operator, total_phase)
 
 def trotterize_w_cRz(operator, ancilla_qubit_idx, factor=1.0, Use_open_cRz=False, trotter_number=1, trotter_order=1):
 
     """
-    returns a circuit equivilant to an exponentiated QubitOperator in which each term
+    Returns a circuit equivalent to an exponentiated QubitOperator in which each term
     in the trotterization exp(-i * theta_k ) only acts on the register if the ancilla
     qubit is in the |1> state.
 
@@ -72,26 +72,18 @@ def trotterize_w_cRz(operator, ancilla_qubit_idx, factor=1.0, Use_open_cRz=False
     is the exponent (N) for to product of single term
     exponentals e^A ~ ( Product_i(e^(A_i/N)) )^N
 
-    :param trotter_order: (int) the order of the troterization approximation, can be 1 or 2
+    :param trotter_order: (int) the order of the trotterization approximation, can be 1 or 2
     """
 
     total_phase = 1.0
-    troterized_operator = qforte.Circuit()
+    trotterized_operator = qforte.Circuit()
 
     if (trotter_number == 1) and (trotter_order == 1):
-        #loop over terms in operator
-        if(Use_open_cRz):
-            for term in operator.terms():
-                term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
-                for gate in term_generator.gates():
-                    troterized_operator.add(gate)
-                total_phase *= phase
-        else:
-            for term in operator.terms():
-                term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
-                for gate in term_generator.gates():
-                    troterized_operator.add(gate)
-                total_phase *= phase
+        for term in operator.terms():
+            term_generator, phase = qforte.exponentiate_pauli_string(factor*term[0],term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=Use_open_cRz)
+            for gate in term_generator.gates():
+                trotterized_operator.add(gate)
+            total_phase *= phase
 
     else:
         if(trotter_order > 1):
@@ -102,17 +94,10 @@ def trotterize_w_cRz(operator, ancilla_qubit_idx, factor=1.0, Use_open_cRz=False
             for term in operator.terms():
                 ho_op.add( factor*term[0] / float(trotter_number) , term[1])
 
-        if(Use_open_cRz):
-            for trot_term in ho_op.terms():
-                term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=True)
-                for gate in term_generator.gates():
-                    troterized_operator.add(gate)
-                total_phase *= phase
-        else:
-            for trot_term in ho_op.terms():
-                term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx)
-                for gate in term_generator.gates():
-                    troterized_operator.add(gate)
-                total_phase *= phase
+        for trot_term in ho_op.terms():
+            term_generator, phase = qforte.exponentiate_pauli_string(trot_term[0],trot_term[1], Use_cRz=True, ancilla_idx=ancilla_qubit_idx, Use_open_cRz=Use_open_cRz)
+            for gate in term_generator.gates():
+                trotterized_operator.add(gate)
+            total_phase *= phase
 
-    return (troterized_operator, total_phase)
+    return (trotterized_operator, total_phase)

--- a/tests/test_qpea.py
+++ b/tests/test_qpea.py
@@ -54,10 +54,44 @@ class TestQPE:
         mol.hamiltonian = H2_qubit_hamiltonian
 
         alg = QPE(mol, reference=ref, trotter_number=2)
-        alg.run(t = 0.4,
+        alg.run(guess_energy = -1,
+                t = 0.4,
                 nruns = 100,
                 success_prob = 0.5,
                 num_precise_bits = 8)
 
         Egs = alg.get_gs_energy()
         assert Egs == approx(E_fci, abs=1.1e-3)
+
+    def test_large_eigenvalue(self):
+        E_fci = -20
+
+        coef_vec = [E_fci, 0]
+
+        circ_vec = [
+        Circuit( ), build_circuit('Z_1')
+        ]
+
+        H2_qubit_hamiltonian = QubitOperator()
+        for i in range(len(circ_vec)):
+            H2_qubit_hamiltonian.add(coef_vec[i], circ_vec[i])
+
+        ref = [1,0]
+
+        print('\nBegin QPE test')
+        print('----------------------')
+
+        # make test with algorithm class
+        mol = Molecule()
+        mol.hamiltonian = H2_qubit_hamiltonian
+
+        alg = QPE(mol, reference=ref, trotter_number=2)
+        alg.run(guess_energy = E_fci,
+                t = 1,
+                nruns = 50,
+                success_prob = 0.9,
+                num_precise_bits = 8)
+
+        Egs = alg.get_gs_energy()
+        assert Egs == approx(E_fci, abs=1.1e-3)
+


### PR DESCRIPTION
## Description
This PR does some cleanup of the QPE code and also fixes _a_ bug.

To understand the bug, you need only the following rough model of Quantum Phase Estimation:

QPE:
(1) takes in a hermitian Hamiltonian `H` with eigenvalues `λ_m` and a state `Ψ`
(2) constructs `exp(i*H)`, which has eigenvalues `exp(i*λ_m)`
(3) measures the `exp(i*λ_m)` with probability distribution given by your input state
(4) uses the most probable `exp(i*λ_m)` to back out its `λ_m`

The problem is that `exp(i*λ_m)` is periodic in `λ_m` with intervals of `2π`, so you can only determine λ_m up to a factor of 2π. The previous implementation arbitrarily chose the branch with `[-2π, 0]`. This passed tests because the toy system of H2 had a small eigenvalue. Systems with larger eigenvalues find themselves on the wrong branch.

As a remedy, there is now a new required keyword: guess_energy. QPE will choose to add the number of `2π` to get the `λ_m` as close as possible to guess_energy. This fixes _a_ buggy test case, but there may be more.

## User Notes
- [x] QPE now requires a `guess_energy` to convert from a phase to an energy. This is true on exact quantum computers, as well.

## Checklist
- [x] Added tests to newly working features
- [x] Ready to go!
