### PR TITLE
Removed get_final_energy function and modified conv_status

### DIFF
--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -79,6 +79,7 @@ class SPQE(UCCPQE):
         self._grad_norms = []
         self._tops = []
         self._tamps = []
+        self._stop_macro = False
         self._converged = False
         self._res_vec_evals = 0
         self._res_m_evals = 0
@@ -114,7 +115,7 @@ class SPQE(UCCPQE):
             f.write(f"#{'Iter(k)':>8}{'E(k)':>14}{'N(params)':>17}{'N(CNOT)':>18}{'N(measure)':>20}\n")
             f.write('#-------------------------------------------------------------------------------\n')
 
-        while not self._converged:
+        while not self._stop_macro:
 
             self.update_ansatz()
 
@@ -629,6 +630,7 @@ class SPQE(UCCPQE):
     def conv_status(self):
         if abs(self._curr_res_sq_norm) < abs(self._spqe_thresh * self._spqe_thresh):
             self._converged = True
+            self._stop_macro = True
             print("\n\n\n------------------------------------------------")
             print("SPQE macro-iterations converged!")
             print(f'||r|| = {np.sqrt(self._curr_res_sq_norm):8.6f}')
@@ -638,12 +640,12 @@ class SPQE(UCCPQE):
             print("Maximum number of SPQE macro-iterations reached!")
             print(f'Current value of ||r||: {np.sqrt(self._curr_res_sq_norm):8.6f}')
             print("------------------------------------------------")
-            self._converged = True
+            self._converged = False
+            self._stop_macro = True
         elif len(self._tops) == len(self._pool_obj):
             print("\n\n\n------------------------------------------------")
             print("Operator pool has been drained!")
             print(f'Current value of ||r||: {np.sqrt(self._curr_res_sq_norm):8.6f}')
             print("------------------------------------------------")
             self._converged = True
-        else:
-            self._converged = False
+            self._stop_macro = True


### PR DESCRIPTION
## Description
Simplified the SPQE code. Removed the get_final_energy function. The modified conv_status function checks whether:
1) SPQE has converged
2) The maximum number of macro-iterations has been reached
3) The operator pool has been completely drained
In any case, it prints the current norm of the residual vector. To accomplish this, some reordering of printing statements was needed.

In a future PR, some related attributes, currently used by other parts of the code, will also be removed.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
