### PR TITLE
Defined anti-CNOT and added test

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -206,7 +206,7 @@ PYBIND11_MODULE(qforte, m) {
         "gate",
         [](std::string type, size_t target, size_t control) {
             // test for two-qubit gates that require no parameters
-            auto vec = {"SWAP", "cV", "CNOT", "cX", "cY", "cZ"};
+            auto vec = {"SWAP", "cV", "CNOT", "cX", "aCNOT", "acX","cY", "cZ"};
             if (std::find(vec.begin(), vec.end(), type) != vec.end()) {
                 return make_gate(type, target, control, 0.0);
             }

--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -112,7 +112,8 @@ std::complex<double> Circuit::canonicalize_pauli_circuit() {
 int Circuit::get_num_cnots() const {
     int n_cnots = 0;
     for (const auto& gate : gates_) {
-        if(gate.gate_id() == "CNOT" || gate.gate_id() == "cX"){
+        if(gate.gate_id() == "CNOT" || gate.gate_id() == "cX" ||
+                gate.gate_id() == "aCNOT" || gate.gate_id() == "acX"){
             n_cnots++;
         } else if (gate.gate_id() == "A"){
             n_cnots += 3;

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -153,6 +153,15 @@ Gate make_gate(std::string type, size_t target, size_t control, std::complex<dou
             };
             return Gate(type, target, control, gate);
         }
+        if ((type == "acX") or (type == "aCNOT")) {
+            std::complex<double> gate[4][4]{
+                {0.0, 1.0, 0.0, 0.0},
+                {1.0, 0.0, 0.0, 0.0},
+                {0.0, 0.0, 1.0, 0.0},
+                {0.0, 0.0, 0.0, 1.0},
+            };
+            return Gate(type, target, control, gate);
+        }
         if (type == "cY") {
             std::complex<double> gate[4][4]{
                 {1.0, 0.0, 0.0, 0.0},

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -133,6 +133,67 @@ class TestGates:
         with pytest.raises(ValueError):
             gate('CNOT',0,1.0)
 
+    def test_acX_gate(self):
+        # test the acX/aCNOT gate
+        nqubits = 2
+        basis0 = make_basis('00') # basis0:|00>
+        basis1 = make_basis('01') # basis1:|10>
+        basis2 = make_basis('10') # basis2:|01>
+        basis3 = make_basis('11') # basis3:|11>
+        computer = Computer(nqubits)
+        aCNOT = gate('aCNOT',0,1);
+
+        # test aCNOT|00> = |01>
+        computer.set_state([(basis0,1.0)])
+        computer.apply_gate(aCNOT)
+        coeff0 = computer.coeff(basis0)
+        coeff1 = computer.coeff(basis1)
+        coeff2 = computer.coeff(basis2)
+        coeff3 = computer.coeff(basis3)
+        assert coeff0 == approx(0, abs=1.0e-16)
+        assert coeff1 == approx(0, abs=1.0e-16)
+        assert coeff2 == approx(1, abs=1.0e-16)
+        assert coeff3 == approx(0, abs=1.0e-16)
+
+        # test aCNOT|10> = |10>
+        computer.set_state([(basis1,1.0)])
+        computer.apply_gate(aCNOT)
+        coeff0 = computer.coeff(basis0)
+        coeff1 = computer.coeff(basis1)
+        coeff2 = computer.coeff(basis2)
+        coeff3 = computer.coeff(basis3)
+        assert coeff0 == approx(0, abs=1.0e-16)
+        assert coeff1 == approx(1, abs=1.0e-16)
+        assert coeff2 == approx(0, abs=1.0e-16)
+        assert coeff3 == approx(0, abs=1.0e-16)
+
+        # test aCNOT|01> = |00>
+        computer.set_state([(basis2,1.0)])
+        computer.apply_gate(aCNOT)
+        coeff0 = computer.coeff(basis0)
+        coeff1 = computer.coeff(basis1)
+        coeff2 = computer.coeff(basis2)
+        coeff3 = computer.coeff(basis3)
+        assert coeff0 == approx(1, abs=1.0e-16)
+        assert coeff1 == approx(0, abs=1.0e-16)
+        assert coeff2 == approx(0, abs=1.0e-16)
+        assert coeff3 == approx(0, abs=1.0e-16)
+
+        # test aCNOT|11> = |11>
+        computer.set_state([(basis3,1.0)])
+        computer.apply_gate(aCNOT)
+        coeff0 = computer.coeff(basis0)
+        coeff1 = computer.coeff(basis1)
+        coeff2 = computer.coeff(basis2)
+        coeff3 = computer.coeff(basis3)
+        assert coeff0 == approx(0, abs=1.0e-16)
+        assert coeff1 == approx(0, abs=1.0e-16)
+        assert coeff2 == approx(0, abs=1.0e-16)
+        assert coeff3 == approx(1, abs=1.0e-16)
+
+        with pytest.raises(ValueError):
+            gate('aCNOT',0,1.0)
+
     def test_cY_gate(self):
         # test the cY gate
         nqubits = 2


### PR DESCRIPTION
## Description
Added the anti-control NOT (aCNOT) gate defined as:
aCNOT(control, target) = |0><0| x X + |1><1| x I
This gate will be used in the CNOT-efficient fermionic/qubit excitation circuits.

Added a test for aCNOT in test_gates.py

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ x] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ x] Ready to go!
