### PR TITLE
Added qubit excitations

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -224,6 +224,9 @@ class AnsatzAlgorithm(Algorithm):
     _tamps : list
         A list of amplitudes (to be optimized) representing selected
         operators in the pool.
+
+    _qubit_excitations: bool
+        Controls the use of qubit/fermionic excitations.
     """
 
     # TODO (opt major): write a C function that prepares this super efficiently
@@ -294,13 +297,15 @@ class AnsatzAlgorithm(Algorithm):
 
         return val
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, qubit_excitations=False,
+            **kwargs):
         super().__init__(*args, **kwargs)
         self._curr_energy = 0
         self._Nm = []
         self._tamps = []
         self._tops = []
         self._pool_obj = qf.SQOpPool()
+        self._qubit_excitations = qubit_excitations
 
         kwargs.setdefault('irrep', None)
         if hasattr(self._sys, 'point_group'):

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -145,7 +145,7 @@ class UCCVQE(VQE, UCC):
         mu = M-1
 
         # find <sing_N | K_N | psi_N>
-        Kmu_prev = self._pool_obj[self._tops[mu]][1].jw_transform()
+        Kmu_prev = self._pool_obj[self._tops[mu]][1].jw_transform(self._qubit_excitations)
         Kmu_prev.mult_coeffs(self._pool_obj[self._tops[mu]][0])
 
         qc_psi.apply_operator(Kmu_prev)
@@ -166,7 +166,7 @@ class UCCVQE(VQE, UCC):
             else:
                 tamp = params[mu+1]
 
-            Kmu = self._pool_obj[self._tops[mu]][1].jw_transform()
+            Kmu = self._pool_obj[self._tops[mu]][1].jw_transform(self._qubit_excitations)
             Kmu.mult_coeffs(self._pool_obj[self._tops[mu]][0])
 
             Umu, pmu = trotterize(Kmu_prev, factor=-tamp, trotter_number=self._trotter_number)
@@ -212,7 +212,7 @@ class UCCVQE(VQE, UCC):
         grads = np.zeros(len(self._pool_obj))
 
         for mu, (coeff, operator) in enumerate(self._pool_obj):
-            Kmu = operator.jw_transform()
+            Kmu = operator.jw_transform(self._qubit_excitations)
             Kmu.mult_coeffs(coeff)
             qc_psi.apply_operator(Kmu)
             grads[mu] = 2.0 * np.real(np.vdot(qc_sig.get_coeff_vec(), qc_psi.get_coeff_vec()))

--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -46,7 +46,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("terms", &SQOperator::terms)
         .def("canonical_order", &SQOperator::canonical_order)
         .def("simplify", &SQOperator::simplify)
-        .def("jw_transform", &SQOperator::jw_transform)
+        .def("jw_transform", &SQOperator::jw_transform, py::arg("qubit_excitation") = false)
         .def("str", &SQOperator::str)
         .def("__str__", &SQOperator::str)
         .def("__repr__", &SQOperator::str);
@@ -60,7 +60,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("set_orb_spaces", &SQOpPool::set_orb_spaces)
         .def("get_qubit_op_pool", &SQOpPool::get_qubit_op_pool)
         .def("get_qubit_operator", &SQOpPool::get_qubit_operator, py::arg("order_type"),
-             py::arg("combine_like_terms") = true)
+             py::arg("combine_like_terms") = true, py::arg("qubit_excitations") = false)
         .def("fill_pool", &SQOpPool::fill_pool)
         .def("str", &SQOpPool::str)
         .def("__getitem__", [](const SQOpPool &pool, size_t i) { return pool.terms()[i]; })

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -66,7 +66,7 @@ QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool c
 
     if(order_type=="unique_lex"){
         for (auto& term : terms_) {
-            auto child = term.second.jw_transform((qubit_excitations);
+            auto child = term.second.jw_transform(qubit_excitations);
             child.mult_coeffs(term.first);
             parent.add_op(child);
         }
@@ -76,7 +76,7 @@ QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool c
         parent.order_terms();
     } else if (order_type=="commuting_grp_lex") {
         for (auto& term : terms_) {
-            auto child = term.second.jw_transform((qubit_excitations);
+            auto child = term.second.jw_transform(qubit_excitations);
             child.mult_coeffs(term.first);
             child.simplify(combine_like_terms=combine_like_terms);
             child.order_terms();

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -61,12 +61,12 @@ QubitOpPool SQOpPool::get_qubit_op_pool(){
 }
 
 
-QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool combine_like_terms){
+QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool combine_like_terms, bool qubit_excitations){
     QubitOperator parent;
 
     if(order_type=="unique_lex"){
         for (auto& term : terms_) {
-            auto child = term.second.jw_transform();
+            auto child = term.second.jw_transform((qubit_excitations);
             child.mult_coeffs(term.first);
             parent.add_op(child);
         }
@@ -76,7 +76,7 @@ QubitOperator SQOpPool::get_qubit_operator(const std::string& order_type, bool c
         parent.order_terms();
     } else if (order_type=="commuting_grp_lex") {
         for (auto& term : terms_) {
-            auto child = term.second.jw_transform();
+            auto child = term.second.jw_transform((qubit_excitations);
             child.mult_coeffs(term.first);
             child.simplify(combine_like_terms=combine_like_terms);
             child.order_terms();

--- a/src/qforte/sq_op_pool.h
+++ b/src/qforte/sq_op_pool.h
@@ -34,7 +34,7 @@ class SQOpPool {
     QubitOpPool get_qubit_op_pool();
 
     /// returns a single QubitOperator of the JW transformed sq ops
-    QubitOperator get_qubit_operator(const std::string& order_type, bool combine_like_terms=true);
+    QubitOperator get_qubit_operator(const std::string& order_type, bool combine_like_terms=true, bool qubit_excitations=false);
 
     /// builds the sq operator pool
     void fill_pool(std::string pool_type);

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -102,7 +102,7 @@ bool SQOperator::permutation_phase(std::vector<int> p) const {
     }
 }
 
-void SQOperator::jw_helper(QubitOperator& holder, const std::vector<size_t>& operators, bool creator) const {
+void SQOperator::jw_helper(QubitOperator& holder, const std::vector<size_t>& operators, bool creator, bool qubit_excitation) const {
     std::complex<double> halfi(0.0, 0.5);
     if (creator) { halfi *= -1; };
 
@@ -111,9 +111,11 @@ void SQOperator::jw_helper(QubitOperator& holder, const std::vector<size_t>& ope
         Circuit Xcirc;
         Circuit Ycirc;
 
-        for (int k = 0; k < sq_op; k++) {
-            Xcirc.add_gate(make_gate("Z", k, k));
-            Ycirc.add_gate(make_gate("Z", k, k));
+        if (not qubit_excitation) {
+            for (int k = 0; k < sq_op; k++) {
+                Xcirc.add_gate(make_gate("Z", k, k));
+                Ycirc.add_gate(make_gate("Z", k, k));
+            }
         }
 
         Xcirc.add_gate(make_gate("X", sq_op, sq_op));
@@ -129,7 +131,7 @@ void SQOperator::jw_helper(QubitOperator& holder, const std::vector<size_t>& ope
     }
 }
 
-QubitOperator SQOperator::jw_transform() {
+QubitOperator SQOperator::jw_transform(bool qubit_excitation) {
     simplify();
     QubitOperator qo;
 
@@ -147,8 +149,8 @@ QubitOperator SQOperator::jw_transform() {
         }
 
         QubitOperator temp1;
-        jw_helper(temp1, std::get<1>(fermion_operator), true);
-        jw_helper(temp1, std::get<2>(fermion_operator), false);
+        jw_helper(temp1, std::get<1>(fermion_operator), true, qubit_excitation);
+        jw_helper(temp1, std::get<2>(fermion_operator), false, qubit_excitation);
 
         temp1.mult_coeffs(std::get<0>(fermion_operator));
         qo.add_op(temp1);

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -132,6 +132,9 @@ void SQOperator::jw_helper(QubitOperator& holder, const std::vector<size_t>& ope
 }
 
 QubitOperator SQOperator::jw_transform(bool qubit_excitation) {
+    /// The simplify() function also brings second-quantized operators
+    /// to normal order. This also ensures the 1-to-1 mapping between
+    /// second-quantized and qubit operators when qubit_excitation=True
     simplify();
     QubitOperator qo;
 

--- a/src/qforte/sq_operator.h
+++ b/src/qforte/sq_operator.h
@@ -59,6 +59,10 @@ class SQOperator {
     /// transform of this sq operator. Calls simplify as a side-effect.
     /// If qubit_excitation = true, replace fermionic creation/annihilation
     /// operators by qubit ones.
+    /// WARNING: In the current implementation of qubit excitations,
+    /// the 1-to-1 mapping between second-quantized operators and their
+    /// qubit excitation counterparts is ensured by the normal ordering of
+    /// second-quantized operators
     QubitOperator jw_transform(bool qubit_excitation = false);
 
     /// return a vector of string representing this quantum operator

--- a/src/qforte/sq_operator.h
+++ b/src/qforte/sq_operator.h
@@ -57,7 +57,9 @@ class SQOperator {
 
     /// Return the QubitOperator object corresponding the the Jordan-Wigner
     /// transform of this sq operator. Calls simplify as a side-effect.
-    QubitOperator jw_transform();
+    /// If qubit_excitation = true, replace fermionic creation/annihilation
+    /// operators by qubit ones.
+    QubitOperator jw_transform(bool qubit_excitation = false);
 
     /// return a vector of string representing this quantum operator
     std::string str() const;
@@ -73,7 +75,7 @@ class SQOperator {
 
     /// If operators is a vector of orbital indices, add the corresponding creator
     /// or annihilation qubit operators to holder.
-    void jw_helper(QubitOperator& holder, const std::vector<size_t>& operators, bool creator) const;
+    void jw_helper(QubitOperator& holder, const std::vector<size_t>& operators, bool creator, bool qubit_excitation) const;
 };
 
 #endif // _sq_operator_h_

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -221,6 +221,7 @@ class ADAPTVQE(UCCVQE):
         else:
             print('Measurement varience thresh:             ',  0.01)
 
+        print('Use qubit excitations: ', self._qubit_excitations)
 
         # VQE options.
         opt_thrsh_str = '{:.2e}'.format(self._opt_thresh)

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -195,6 +195,8 @@ class SPQE(UCCPQE):
         else:
             print('Measurement varience thresh:             ',  0.01)
 
+        print('Use qubit excitations: ', self._qubit_excitations)
+
         opt_thrsh_str = '{:.2e}'.format(self._opt_thresh)
         spqe_thrsh_str = '{:.2e}'.format(self._spqe_thresh)
         print('DIIS maxiter:                            ',  self._opt_maxiter)
@@ -351,7 +353,7 @@ class SPQE(UCCPQE):
 
                 qc_temp = qforte.Computer(self._nqb)
                 qc_temp.apply_circuit(self._Uprep)
-                qc_temp.apply_operator(sq_op.jw_transform())
+                qc_temp.apply_operator(sq_op.jw_transform(self._qubit_excitations))
                 sign_adjust = qc_temp.get_coeff_vec()[I]
 
                 res_m = coeffs[I] * sign_adjust

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -137,6 +137,8 @@ class UCCNPQE(UCCPQE):
         else:
             print('Measurement varience thresh:             ',  0.01)
 
+        print('Use qubit excitations: ', self._qubit_excitations)
+
         res_thrsh_str = '{:.2e}'.format(self._opt_thresh)
         print('DIIS maxiter:                            ',  self._opt_maxiter)
         print('DIIS res-norm threshold:                 ',  res_thrsh_str)
@@ -213,7 +215,7 @@ class UCCNPQE(UCCPQE):
 
             qc_temp = qforte.Computer(self._nqb)
             qc_temp.apply_circuit(self._Uprep)
-            qc_temp.apply_operator(sq_op.jw_transform())
+            qc_temp.apply_operator(sq_op.jw_transform(self._qubit_excitations))
             phase_factor = qc_temp.get_coeff_vec()[I]
 
             self._excited_dets.append((I, phase_factor))

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -129,6 +129,7 @@ class UCCNVQE(UCCVQE):
         else:
             print('Measurement variance thresh:             ',  0.01)
 
+        print('Use qubit excitations: ', self._qubit_excitations)
 
         # VQE options.
         opt_thrsh_str = '{:.2e}'.format(self._opt_thresh)

--- a/tests/test_jw_transform.py
+++ b/tests/test_jw_transform.py
@@ -163,7 +163,7 @@ class TestJordanWigner:
         def test_jw_qubit_2(self):
             # In this test we confirm that the there exists a 1-to-1 mapping between
             # second-quantized fermionic operators and qubit excitation operators.
-            # The uniqueness is guarantedd by the normal ordering of second-quantized
+            # The uniqueness is guaranteed by the normal ordering of second-quantized
             # operators
             sq_op1 = qf.SQOperator()
             sq_op1.add(1,[1,0],[])

--- a/tests/test_jw_transform.py
+++ b/tests/test_jw_transform.py
@@ -129,3 +129,33 @@ class TestJordanWigner:
         a.add(1.00, [1], [3, 4])
         aop = a.jw_transform()
         assert aop.check_op_equivalence(correct_op, True) is True
+
+        def test_jw_qubit(self):
+            # In this test we check the JW transform for fermionic and qubit excitations.
+            # We test the action of the a_3, a^3, Q_3, Q^3 on the |1110> and |1111>
+            # qubit basis states
+            fermion_create_3 = qf.SQOperator()
+            fermion_annihilate_3 = qf.SQOperator()
+            fermion_create_3.add(1, [3], [])
+            fermion_annihilate_3.add(1, [], [3])
+            expected = [[0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, (-1+0j)],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, (1+0j)],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, (-1+0j), 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j],
+                        [0j, 0j, 0j, 0j, 0j, 0j, 0j, (1+0j), 0j, 0j, 0j, 0j, 0j, 0j, 0j, 0j]]
+            results = []
+            for sq_operator in [fermion_create_3, fermion_annihilate_3]:
+                for n_occupied in [3,4]:
+                    for qubit_excitations in [False, True]:
+                        # create desired qubit state
+                        comp = qf.Computer(4)
+                        for occupied in range(n_occupied):
+                            comp.apply_gate(qf.gate('X', occupied))
+                        # transform second-quanitzed operators using JW
+                        q_operator = sq_operator.jw_transform(qubit_excitations)
+                        comp.apply_operator(q_operator)
+                        results.append(comp.get_coeff_vec())
+            assert results == expected

--- a/tests/test_jw_transform.py
+++ b/tests/test_jw_transform.py
@@ -159,3 +159,16 @@ class TestJordanWigner:
                         comp.apply_operator(q_operator)
                         results.append(comp.get_coeff_vec())
             assert results == expected
+
+        def test_jw_qubit_2(self):
+            # In this test we confirm that the there exists a 1-to-1 mapping between
+            # second-quantized fermionic operators and qubit excitation operators.
+            # The uniqueness is guarantedd by the normal ordering of second-quantized
+            # operators
+            sq_op1 = qf.SQOperator()
+            sq_op1.add(1,[1,0],[])
+            q_op1 = sq_op1.jw_transform(True)
+            sq_op2 = qf.SQOperator()
+            sq_op2.add(-1,[0,1],[])
+            q_op2 = sq_op2.jw_transform(True)
+            assert q_op1 == q_op2


### PR DESCRIPTION
## Description
The jw_transform attribute has a new, boolean, optional argument allowing for qubit excitations (essentially neglecting the strings of Z gates). the test_jw_transform.py file has been updated with a new test confirming the new functionality.

## User Notes
- [ x] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ x] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ x] Ready to go!
