### PR TITLE
Added maximum excitation rank for SPQE operator pool

### DIFF
--- a/tests/test_spqe.py
+++ b/tests/test_spqe.py
@@ -1,5 +1,5 @@
 from pytest import approx
-from qforte import QubitOperator, smart_print, system_factory, SPQE
+from qforte import QubitOperator, smart_print, system_factory, SPQE, UCCNPQE
 
 import os
 
@@ -37,3 +37,37 @@ class TestSPQE:
         # Egs = Egs_elec + Enuc
         Egs = Egs_elec
         assert Egs == approx(Efci, abs=5.0e-11)
+
+    def test_spqe_max_excit_rank(self):
+
+        Rhh = 1.5
+
+        mol = system_factory(system_type = 'molecule',
+                build_type = 'psi4',
+                basis = 'sto-6g',
+                mol_geometry = [('H', (0, 0, -3*Rhh/2)),
+                                ('H', (0, 0, -Rhh/2)),
+                                ('H', (0, 0, Rhh/2)),
+                                ('H', (0, 0, 3*Rhh/2))],
+                symmetry = 'd2h',
+                multiplicity = 1, # Only singlets will work with QForte
+                charge = 0,
+                num_frozen_docc = 0,
+                num_frozen_uocc = 0,
+                run_mp2=0,
+                run_ccsd=0,
+                run_cisd=0,
+                run_fci=0)
+
+        uccnpqe_sd = UCCNPQE(mol, verbose=False)
+        uccnpqe_sd.run(pool_type='SD', opt_thresh=1.0e-5, opt_maxiter=50)
+
+        spqe_sd = SPQE(mol, verbose=False)
+        spqe_sd.run(spqe_thresh=0, spqe_maxiter=1, opt_maxiter=50, opt_thresh=1.0e-5, use_cumulative_thresh=True,
+                        max_excit_rank=2)
+
+        assert len(spqe_sd._pool_obj) == len(uccnpqe_sd._pool_obj)
+        # Although both algorithms utilize ansatze containing the same operators,
+        # their ordering is different. Thus the UCCSD energies resulting from the
+        # SPQE and UCCNPQE algorithms will not be identical
+        assert spqe_sd._Egs == approx(uccnpqe_sd._Egs, abs = 1.0e-5)


### PR DESCRIPTION
## Description
Added a max_excit_rank parameter for SPQE, controlling the maximum excitation rank of the operators in the pool. By setting spqe_thresh=0, this also extends the functionality of SPQE as a fixed-ansatz UCC scheme of arbitrary excitation rank. Note, however, that the energies obtained with the UCCNPQE algorithm will slightly differ from their counterparts resulting from the SPQE code since the ordering of the operators is different.

Also added a test in test_spqe.py.

## User Notes
- [x ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
