### PR TITLE
Added residual minimization for SPQE and UCCNPQE

### DIFF
--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -56,3 +56,28 @@ class UCCPQE(PQE, UCC):
     #TODO: consider moving functions from uccnpqe or spqe into this class to
     #      to prevent duplication of code
 
+    def report_iteration(self, x):
+        # Printing function for residual minimization. This function is passed to scipy minimize
+        # as a callback
+
+        self._k_counter += 1
+
+        if(self._k_counter == 1):
+            print('\n    k iteration         Energy               dE           Nrvec ev      Nrm ev*         ||r||')
+            print('--------------------------------------------------------------------------------------------------')
+            if (self._print_summary_file):
+                f = open("summary.dat", "w+", buffering=1)
+                f.write('\n#    k iteration         Energy               dE           Nrvec ev      Nrm ev*         ||r||')
+                f.write('\n#--------------------------------------------------------------------------------------------------')
+                f.close()
+
+        self._curr_energy = self.energy_feval(x)
+        dE = self._curr_energy - self._prev_energy
+        print(f'     {self._k_counter:7}        {self._curr_energy:+12.10f}      {dE:+12.10f}      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._res_vec_norm:+12.10f}')
+
+        if (self._print_summary_file):
+            f = open("summary.dat", "a", buffering=1)
+            f.write(f'\n       {self._k_counter:7}        {self._curr_energy:+12.12f}      {dE:+12.12f}      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._res_vec_norm:+12.12f}')
+            f.close()
+
+        self._prev_energy = self._curr_energy

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -81,3 +81,18 @@ class UCCPQE(PQE, UCC):
             f.close()
 
         self._prev_energy = self._curr_energy
+
+    def get_sum_residual_square(self, tamps):
+        # This function is passed to scipy minimize for residual minimization
+        residual_vector = self.get_residual_vector(tamps)
+        sum_residual_vector_square = np.sum(np.square(residual_vector))
+        return sum_residual_vector_square
+
+    def solve(self):
+        if self._optimizer.lower() == 'jacobi':
+            self.jacobi_solver()
+        elif self._optimizer.lower() in ['nelder-mead', 'powell', 'bfgs', 'l-bfgs-b', 'cg', 'slsqp']:
+            self.scipy_solver(self.get_sum_residual_square)
+        else:
+            raise NotImplementedError('Currently only Jacobi, Nelder-Mead, Powell, BFGS, L-BFGS-B, CG, and SLSQP solvers are implemented')
+

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -275,14 +275,6 @@ class SPQE(UCCPQE):
         print('Number of residual vector evaluations:       ', self._res_vec_evals)
         print('Number of individual residual evaluations:   ', self._res_m_evals)
 
-    def solve(self, ):
-        if self._optimizer.lower() == 'jacobi':
-            self.jacobi_solver()
-        elif self._optimizer.lower() in ['nelder-mead', 'powell', 'bfgs', 'l-bfgs-b', 'cg', 'slsqp']:
-            self.scipy_solver(self.get_sum_residual_square)
-        else:
-            raise NotImplementedError('Currently only Jacobi, Nelder-Mead, Powell, BFGS, L-BFGS-B, CG, and SLSQP solvers are implemented')
-
     def get_residual_vector(self, trial_amps):
         U = self.ansatz_circuit(trial_amps)
 
@@ -328,12 +320,6 @@ class SPQE(UCCPQE):
             self._res_m_evals += len(trial_amps)
 
         return residuals
-
-    def get_sum_residual_square(self, tamps):
-        # This function is passed to scipy minimize for residual minimization
-        residual_vector = self.get_residual_vector(tamps)
-        sum_residual_vector_square = np.sum(np.square(residual_vector))
-        return sum_residual_vector_square
 
     def update_ansatz(self):
         self._n_pauli_measures_k = 0

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -169,14 +169,6 @@ class UCCNPQE(UCCPQE):
         print('Number of residual element evaluations*:     ', self._res_m_evals)
         print('Number of non-zero res element evaluations:  ', int(self._res_vec_evals)*self._n_nonzero_params)
 
-    def solve(self):
-        if self._optimizer.lower() == 'jacobi':
-            self.jacobi_solver()
-        elif self._optimizer.lower() in ['nelder-mead', 'powell', 'bfgs', 'l-bfgs-b', 'cg', 'slsqp']:
-            self.scipy_solver(self.get_sum_residual_square)
-        else:
-            raise NotImplementedError('Currently only Jacobi, Nelder-Mead, Powell, BFGS, L-BFGS-B, CG, and SLSQP solvers are implemented')
-
     def fill_excited_dets(self):
         for _, sq_op in self._pool_obj:
             # 1. Identify the excitation operator
@@ -274,13 +266,6 @@ class UCCNPQE(UCCPQE):
         self._res_m_evals += len(self._tamps)
 
         return residuals
-
-    def get_sum_residual_square(self, tamps):
-        # This function is passed to scipy minimize for residual minimization
-        residual_vector = self.get_residual_vector(tamps)
-        sum_residual_vector_square = np.sum(np.square(residual_vector))
-        return sum_residual_vector_square
-
 
     def initialize_ansatz(self):
         """Adds all operators in the pool to the list of operators in the circuit,


### PR DESCRIPTION
## Description
Added residual minimization functionality for UCCNPQE and SPQE classes. The minimization is based on scipy.

Added a couple of tests for the new features.

In a future PR, the scipy solver for UCCNVQE and ADAPTVQE will be replaced by the scipy solver in the optimizer.py file.

## User Notes
- [x ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
