### PR TITLE
Moment energy corrections

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -301,8 +301,8 @@ class AnsatzAlgorithm(Algorithm):
 
         return val
 
-    def __init__(self, *args, qubit_excitations=False, compact_excitations=False, diis_max_dim=8, mmcc = True,
-            max_moment_rank = None,
+    def __init__(self, *args, qubit_excitations=False, compact_excitations=False, diis_max_dim=8,
+            max_moment_rank = 0,
             **kwargs):
         super().__init__(*args, **kwargs)
         self._curr_energy = 0
@@ -313,7 +313,10 @@ class AnsatzAlgorithm(Algorithm):
         self._qubit_excitations = qubit_excitations
         self._compact_excitations = compact_excitations
         self._diis_max_dim = diis_max_dim
-        self._mmcc = mmcc
+        # The max_moment_rank controls the calculation of non-iterative energy corrections
+        # based on the method of moments of coupled-cluster theory.
+        # max_moment_rank = 0: non-iterative correction skipped
+        # max_moment_rank = n: projections up to n-tuply excited Slater determinants are considered
         self._max_moment_rank = max_moment_rank
 
         kwargs.setdefault('irrep', None)

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -301,7 +301,8 @@ class AnsatzAlgorithm(Algorithm):
 
         return val
 
-    def __init__(self, *args, qubit_excitations=False, compact_excitations=False, diis_max_dim=8,
+    def __init__(self, *args, qubit_excitations=False, compact_excitations=False, diis_max_dim=8, mmcc = True,
+            max_moment_rank = None,
             **kwargs):
         super().__init__(*args, **kwargs)
         self._curr_energy = 0
@@ -312,6 +313,8 @@ class AnsatzAlgorithm(Algorithm):
         self._qubit_excitations = qubit_excitations
         self._compact_excitations = compact_excitations
         self._diis_max_dim = diis_max_dim
+        self._mmcc = mmcc
+        self._max_moment_rank = max_moment_rank
 
         kwargs.setdefault('irrep', None)
         if hasattr(self._sys, 'point_group'):

--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -302,7 +302,7 @@ class AnsatzAlgorithm(Algorithm):
         return val
 
     def __init__(self, *args, qubit_excitations=False, compact_excitations=False, diis_max_dim=8,
-            max_moment_rank = 0,
+            max_moment_rank = 0, moment_dt=None,
             **kwargs):
         super().__init__(*args, **kwargs)
         self._curr_energy = 0
@@ -318,6 +318,8 @@ class AnsatzAlgorithm(Algorithm):
         # max_moment_rank = 0: non-iterative correction skipped
         # max_moment_rank = n: projections up to n-tuply excited Slater determinants are considered
         self._max_moment_rank = max_moment_rank
+        # The moment_dt variable defines the 'residual' state used to measure the residuals for the moment corrections
+        self._moment_dt = moment_dt
 
         kwargs.setdefault('irrep', None)
         if hasattr(self._sys, 'point_group'):

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -127,7 +127,7 @@ class ADAPTVQE(UCCVQE):
 
         self.fill_pool()
 
-        if self._mmcc:
+        if self._max_moment_rank:
             print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
             self.construct_moment_space()
 
@@ -159,7 +159,7 @@ class ADAPTVQE(UCCVQE):
 
             self.solve()
 
-            if self._mmcc:
+            if self._max_moment_rank:
                 print('\nComputing non-iterative energy corrections')
                 self.compute_moment_energies()
 
@@ -187,7 +187,7 @@ class ADAPTVQE(UCCVQE):
         self._Egs = self.get_final_energy()
 
         print('\n\n')
-        if not self._mmcc:
+        if not self._max_moment_rank:
             print(f"{'Iter':>8}{'E':>14}{'N(params)':>17}{'N(CNOT)':>18}{'N(measure)':>20}")
             print('-------------------------------------------------------------------------------')
 
@@ -265,7 +265,7 @@ class ADAPTVQE(UCCVQE):
         print('\n\n                ==> ADAPT-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final ADAPT-VQE Energy:                     ', round(self._Egs, 10))
-        if self._mmcc:
+        if self._max_moment_rank:
             print('Moment-corrected (MP) ADAPT-VQE Energy:     ', round(self._E_mmcc_mp[-1], 10))
             print('Moment-corrected (EN) ADAPT-VQE Energy:     ', round(self._E_mmcc_en[-1], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -13,6 +13,7 @@ from qforte.experiment import *
 from qforte.utils.transforms import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
+from qforte.utils import moment_energy_corrections
 from qforte.maths import optimizer
 
 import numpy as np
@@ -125,6 +126,9 @@ class ADAPTVQE(UCCVQE):
         self.print_options_banner()
 
         self.fill_pool()
+
+        if self._mmcc:
+            self.construct_moment_space()
 
         if self._verbose:
             print('\n\n-------------------------------------')
@@ -447,3 +451,5 @@ class ADAPTVQE(UCCVQE):
             return self._final_result
 
 ADAPTVQE.jacobi_solver = optimizer.jacobi_solver
+ADAPTVQE.construct_moment_space = moment_energy_corrections.construct_moment_space
+ADAPTVQE.compute_moment_energies = moment_energy_corrections.compute_moment_energies

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -128,6 +128,7 @@ class ADAPTVQE(UCCVQE):
         self.fill_pool()
 
         if self._mmcc:
+            print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
             self.construct_moment_space()
 
         if self._verbose:
@@ -158,6 +159,10 @@ class ADAPTVQE(UCCVQE):
 
             self.solve()
 
+            if self._mmcc:
+                print('\nComputing non-iterative energy corrections')
+                self.compute_moment_energies()
+
             if(self._verbose):
                 print('\ntamplitudes for tops post solve: \n', np.real(self._tamps))
 
@@ -182,11 +187,20 @@ class ADAPTVQE(UCCVQE):
         self._Egs = self.get_final_energy()
 
         print('\n\n')
-        print(f"{'Iter(k)':>8}{'E(k)':>14}{'N(params)':>17}{'N(CNOT)':>18}{'N(measure)':>20}")
-        print('-------------------------------------------------------------------------------')
+        if not self._mmcc:
+            print(f"{'Iter':>8}{'E':>14}{'N(params)':>17}{'N(CNOT)':>18}{'N(measure)':>20}")
+            print('-------------------------------------------------------------------------------')
 
-        for k, Ek in enumerate(self._energies):
-            print(f' {k:7}    {Ek:+15.9f}    {self._n_classical_params_lst[k]:8}        {self._n_cnot_lst[k]:10}        {sum(self._n_pauli_trm_measures_lst[:k+1]):12}')
+            for k, Ek in enumerate(self._energies):
+                print(f' {k:7}    {Ek:+15.9f}    {self._n_classical_params_lst[k]:8}        {self._n_cnot_lst[k]:10}        {sum(self._n_pauli_trm_measures_lst[:k+1]):12}')
+
+        else:
+            print(f"{'Iter':>8}{'E':>14}{'E_MMCC(MP)':>24}{'E_MMCC(EN)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}")
+            print('-----------------------------------------------------------------------------------------------------------------------')
+
+            for k, Ek in enumerate(self._energies):
+                print(f' {k+1:7}    {Ek:+15.9f}    {self._E_mmcc_mp[k]:15.9f}    {self._E_mmcc_en[k]:15.9f}    {self._n_classical_params_lst[k]:8}        {self._n_cnot_lst[k]:10}        {sum(self._n_pauli_trm_measures_lst[:k+1]):12}')
+
 
         self._n_classical_params = len(self._tamps)
         self._n_cnot = self._n_cnot_lst[-1]
@@ -251,6 +265,9 @@ class ADAPTVQE(UCCVQE):
         print('\n\n                ==> ADAPT-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final ADAPT-VQE Energy:                     ', round(self._Egs, 10))
+        if self._mmcc:
+            print('Moment-corrected (MP) ADAPT-VQE Energy:     ', round(self._E_mmcc_mp[-1], 10))
+            print('Moment-corrected (EN) ADAPT-VQE Energy:     ', round(self._E_mmcc_en[-1], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Total number of Hamiltonian measurements:    ', self.get_num_ham_measurements())

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -162,12 +162,13 @@ class SPQE(UCCPQE):
         # excitation operator index : determinant id
         self._reversed_excitation_dictionary = {value: key for key, value in self._excitation_dictionary.items()}
 
-        if self._mmcc:
-           self.construct_moment_space()
-
         self.print_options_banner()
 
         self.build_orb_energies()
+
+        if self._mmcc:
+            print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
+            self.construct_moment_space()
 
         self._spqe_iter = 1
 
@@ -190,6 +191,7 @@ class SPQE(UCCPQE):
             self.solve()
 
             if self._mmcc:
+                print('\nComputing non-iterative energy corrections')
                 self.compute_moment_energies()
 
             if(self._verbose):
@@ -222,7 +224,7 @@ class SPQE(UCCPQE):
 
         else:
             print(f"{'Iter':>8}{'E':>14}{'E_MMCC(MP)':>24}{'E_MMCC(EN)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}")
-            print('-------------------------------------------------------------------------------')
+            print('-----------------------------------------------------------------------------------------------------------------------')
 
             for k, Ek in enumerate(self._energies):
                 print(f' {k+1:7}    {Ek:+15.9f}    {self._E_mmcc_mp[k]:15.9f}    {self._E_mmcc_en[k]:15.9f}    {self._n_classical_params_lst[k]:8}        {self._n_cnot_lst[k]:10}        {sum(self._n_pauli_trm_measures_lst[:k+1]):12}')
@@ -282,6 +284,9 @@ class SPQE(UCCPQE):
         print('\n\n                ==> SPQE summary <==')
         print('-----------------------------------------------------------')
         print('Final SPQE Energy:                           ', round(self._Egs, 10))
+        if self._mmcc:
+            print('Moment-corrected (MP) SPQE Energy:           ', round(self._E_mmcc_mp[-1], 10))
+            print('Moment-corrected (EN) SPQE Energy:           ', round(self._E_mmcc_en[-1], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Number of classical parameters used:         ', self._n_classical_params)

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -166,7 +166,7 @@ class SPQE(UCCPQE):
 
         self.build_orb_energies()
 
-        if self._mmcc:
+        if self._max_moment_rank:
             print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
             self.construct_moment_space()
 
@@ -190,7 +190,7 @@ class SPQE(UCCPQE):
 
             self.solve()
 
-            if self._mmcc:
+            if self._max_moment_rank:
                 print('\nComputing non-iterative energy corrections')
                 self.compute_moment_energies()
 
@@ -215,7 +215,7 @@ class SPQE(UCCPQE):
             print(f"{l+1:12}              {nl:14}")
 
         print('\n\n')
-        if not self._mmcc:
+        if not self._max_moment_rank:
             print(f"{'Iter(k)':>8}{'E':>14}{'N(params)':>17}{'N(CNOT)':>18}{'N(measure)':>20}")
             print('-------------------------------------------------------------------------------')
 
@@ -284,7 +284,7 @@ class SPQE(UCCPQE):
         print('\n\n                ==> SPQE summary <==')
         print('-----------------------------------------------------------')
         print('Final SPQE Energy:                           ', round(self._Egs, 10))
-        if self._mmcc:
+        if self._max_moment_rank:
             print('Moment-corrected (MP) SPQE Energy:           ', round(self._E_mmcc_mp[-1], 10))
             print('Moment-corrected (EN) SPQE Energy:           ', round(self._E_mmcc_en[-1], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -96,7 +96,7 @@ class UCCNPQE(UCCPQE):
         self.build_orb_energies()
         self.solve()
 
-        if self._mmcc:
+        if self._max_moment_rank:
             print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
             self.construct_moment_space()
             print('\nComputing non-iterative energy corrections')
@@ -166,7 +166,7 @@ class UCCNPQE(UCCPQE):
         print('\n\n                   ==> UCC-PQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-PQE Energy:                      ', round(self._Egs, 10))
-        if self._mmcc:
+        if self._max_moment_rank:
             print('Moment-corrected (MP) UCCN-PQE Energy:      ', round(self._E_mmcc_mp[0], 10))
             print('Moment-corrected (EN) UCCN-PQE Energy:      ', round(self._E_mmcc_en[0], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -80,9 +80,6 @@ class UCCNPQE(UCCPQE):
         self.print_options_banner()
         self.fill_pool()
 
-        if self._mmcc:
-            self.construct_moment_space()
-
         if self._verbose:
             print('\n\n-------------------------------------')
             print('   Second Quantized Operator Pool')
@@ -98,6 +95,12 @@ class UCCNPQE(UCCPQE):
         self.fill_excited_dets()
         self.build_orb_energies()
         self.solve()
+
+        if self._mmcc:
+            print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
+            self.construct_moment_space()
+            print('\nComputing non-iterative energy corrections')
+            self.compute_moment_energies()
 
         if(self._verbose):
             print('\nt operators included from pool: \n', self._tops)
@@ -163,6 +166,9 @@ class UCCNPQE(UCCPQE):
         print('\n\n                   ==> UCC-PQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-PQE Energy:                      ', round(self._Egs, 10))
+        if self._mmcc:
+            print('Moment-corrected (MP) UCCN-PQE Energy:      ', round(self._E_mmcc_mp[0], 10))
+            print('Moment-corrected (EN) UCCN-PQE Energy:      ', round(self._E_mmcc_en[0], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Number of classical parameters used:         ', len(self._tamps))

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -13,6 +13,7 @@ from qforte.maths import optimizer
 from qforte.utils.transforms import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
+from qforte.utils import moment_energy_corrections
 
 from qforte.helper.printing import matprint
 
@@ -78,6 +79,9 @@ class UCCNPQE(UCCPQE):
 
         self.print_options_banner()
         self.fill_pool()
+
+        if self._mmcc:
+            self.construct_moment_space()
 
         if self._verbose:
             print('\n\n-------------------------------------')
@@ -277,3 +281,5 @@ class UCCNPQE(UCCPQE):
 
 UCCNPQE.jacobi_solver = optimizer.jacobi_solver
 UCCNPQE.scipy_solver = optimizer.scipy_solver
+UCCNPQE.construct_moment_space = moment_energy_corrections.construct_moment_space
+UCCNPQE.compute_moment_energies = moment_energy_corrections.compute_moment_energies

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -13,6 +13,7 @@ from qforte.maths import optimizer
 from qforte.utils.transforms import *
 from qforte.utils.state_prep import *
 from qforte.utils.trotterization import trotterize
+from qforte.utils import moment_energy_corrections
 
 import numpy as np
 from scipy.optimize import minimize
@@ -73,6 +74,9 @@ class UCCNVQE(UCCVQE):
         ######### UCCN-VQE #########
 
         self.fill_pool()
+
+        if self._mmcc:
+            self.construct_moment_space()
 
         if self._verbose:
             print(self._pool_obj.str())
@@ -268,3 +272,5 @@ class UCCNVQE(UCCVQE):
         return 0
 
 UCCNVQE.jacobi_solver = optimizer.jacobi_solver
+UCCNVQE.construct_moment_space = moment_energy_corrections.construct_moment_space
+UCCNVQE.compute_moment_energies = moment_energy_corrections.compute_moment_energies

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -86,7 +86,7 @@ class UCCNVQE(UCCVQE):
 
         self.solve()
 
-        if self._mmcc:
+        if self._max_moment_rank:
             print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
             self.construct_moment_space()
             print('\nComputing non-iterative energy corrections')
@@ -155,7 +155,7 @@ class UCCNVQE(UCCVQE):
         print('\n\n                ==> UCCN-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-VQE Energy:                      ', round(self._Egs, 10))
-        if self._mmcc:
+        if self._max_moment_rank:
             print('Moment-corrected (MP) UCCN-VQE Energy:      ', round(self._E_mmcc_mp[0], 10))
             print('Moment-corrected (EN) UCCN-VQE Energy:      ', round(self._E_mmcc_en[0], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -75,9 +75,6 @@ class UCCNVQE(UCCVQE):
 
         self.fill_pool()
 
-        if self._mmcc:
-            self.construct_moment_space()
-
         if self._verbose:
             print(self._pool_obj.str())
 
@@ -88,6 +85,12 @@ class UCCNVQE(UCCVQE):
             print('\nInitial tamplitudes for tops: \n', self._tamps)
 
         self.solve()
+
+        if self._mmcc:
+            print('\nConstructing Moller-Plesset and Epstein-Nesbet denominators')
+            self.construct_moment_space()
+            print('\nComputing non-iterative energy corrections')
+            self.compute_moment_energies()
 
         if(self._verbose):
             print('\nt operators included from pool: \n', self._tops)
@@ -152,6 +155,9 @@ class UCCNVQE(UCCVQE):
         print('\n\n                ==> UCCN-VQE summary <==')
         print('-----------------------------------------------------------')
         print('Final UCCN-VQE Energy:                      ', round(self._Egs, 10))
+        if self._mmcc:
+            print('Moment-corrected (MP) UCCN-VQE Energy:      ', round(self._E_mmcc_mp[0], 10))
+            print('Moment-corrected (EN) UCCN-VQE Energy:      ', round(self._E_mmcc_en[0], 10))
         print('Number of operators in pool:                 ', len(self._pool_obj))
         print('Final number of amplitudes in ansatz:        ', len(self._tamps))
         print('Total number of Hamiltonian measurements:    ', self.get_num_ham_measurements())

--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -1,3 +1,15 @@
+"""
+Functions for computing non-iterative energy corrections based on the
+method of moments of coupled-cluster (MMCC) theory. The orginal ideas
+for traditional coupled-cluster approaches can be found in:
+    DOI: 10.1007/BF01117411
+    DOI: 10.1142/9789812792501_0001
+    DOI: 10.1063/1.481769
+    DOI: 10.1063/1.2137318
+The use of such moment corrections in the UCC case is experimental
+and a publication will appear in the future.
+"""
+
 import qforte as qf
 from qforte.utils.trotterization import trotterize
 from qforte.utils.point_groups import sq_op_find_symmetry

--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -1,0 +1,94 @@
+import qforte as qf
+from qforte.utils.trotterization import trotterize
+from qforte.utils.point_groups import sq_op_find_symmetry
+import numpy as np
+
+def construct_moment_space(self):
+
+    # List that will hold the orbital energy differences used in Moller-Plesset denominators
+    self._mpdenom = []
+    # List that will hold <Phi_k| H |Phi_k> used in the Epstein-Nesbet denominators
+    self._epstein_nesbet = []
+
+    self._E_mmcc_mp = []
+    self._E_mmcc_en = []
+
+    # List that will store the integers representing the determinants used in the moment corrections
+    self._mmcc_excitation_indices = []
+    self._mmcc_pool = qf.SQOpPool()
+
+    self.build_orb_energies()
+
+    # create a pool of particle number, Sz, and spatial symmetry adapted second quantized operators
+    # Encode the occupation list into a bitstring
+    ref = sum([b << i for i, b in enumerate(self._ref)])
+    # `& mask_alpha` gives the alpha component of a bitstring. `& mask_beta` does likewise.
+    mask_alpha = 0x5555555555555555
+    mask_beta = mask_alpha << 1
+    nalpha = sum(self._ref[0::2])
+    nbeta = sum(self._ref[1::2])
+
+    if self._max_moment_rank is None:
+        self._max_moment_rank = nalpha + nbeta
+    elif not isinstance(self._max_moment_rank, int) or max_momnet_rank <= 0:
+        raise TypeError("The maximum moment rank must be a positive integer!")
+    elif self._max_moment_rank > nalpha + nbeta:
+        # WARNING: This step could be potetnially removed, if QForte gets methods
+        #          that violate particle number symmetry
+        self._max_moment_rank = nalpha + nbeta
+
+    for I in range(1 << self._nqb):
+        alphas = [int(j) for j in bin(I & mask_alpha)[2:]]
+        betas = [int(j) for j in bin(I & mask_beta)[2:]]
+        # The following checks could be potentially removed, if QForte gets methods
+        # that violate particle number, Sz, and spatial symmetries
+        if sum(alphas) == nalpha and sum(betas) == nbeta:
+            if sq_op_find_symmetry(self._sys.orb_irreps_to_int,
+                                   [len(alphas) - i - 1 for i, x in enumerate(alphas) if x],
+                                   [len(betas) -i - 1 for i, x in enumerate(betas) if x]) == 0:
+                # Create the bitstring of created/annihilated orbitals
+                excit = bin(ref ^ I).replace("0b", "")
+                # Confirm excitation number is non-zero
+                if excit != "0":
+                    # Consider moments with rank <= self._max_moment_rank
+                    if int(excit.count('1')/2) <= self._max_moment_rank:
+                        occ_idx = [int(i) for i,j in enumerate(reversed(excit)) if int(j) == 1 and self._ref[i] == 1]
+                        unocc_idx = [int(i) for i,j in enumerate(reversed(excit)) if int(j) == 1 and self._ref[i] == 0]
+                        sq_op = qf.SQOperator()
+                        sq_op.add(+1.0, unocc_idx, occ_idx)
+                        sq_op.add(-1.0, occ_idx[::-1], unocc_idx[::-1])
+                        sq_op.simplify()
+                        self._mmcc_pool.add_term(0.0, sq_op)
+                        self._mpdenom.append(sum(self._orb_e[x] for x in occ_idx) - sum(self._orb_e[x] for x in unocc_idx))
+                        self._mmcc_excitation_indices.append(I)
+
+    for i in self._mmcc_pool.terms():
+        sq_op = i[1]
+        qc = qf.Computer(self._nqb)
+        qc.apply_circuit(self._Uprep)
+        # This could be replaced by set_bit?
+        qc.apply_operator(sq_op.jw_transform(self._qubit_excitations))
+        self._epstein_nesbet.append(qc.direct_op_exp_val(self._qb_ham))
+
+def compute_moment_energies(self):
+
+    # The moments, i.e., residuals, are estimated by measuring the "residual" state a la SPQE
+    self._eiH, self._eiH_phase = trotterize(self._qb_ham, factor= self._dt*(0.0 + 1.0j), trotter_number=self._trotter_number)
+
+    # do U^dag e^iH U |Phi_o> = |Phi_res>
+    U = self.ansatz_circuit()
+
+    qc_res = qf.Computer(self._nqb)
+    qc_res.apply_circuit(self._Uprep)
+    qc_res.apply_circuit(U)
+    qc_res.apply_circuit(self._eiH)
+    qc_res.apply_circuit(U.adjoint())
+
+    res_coeffs = [i / self._dt for i in qc_res.get_coeff_vec()]
+
+    mmcc_res = [res_coeffs[I] for I in self._mmcc_excitation_indices]
+    mmcc_res_sq_over_mpdenom = [np.real(np.conj(mmcc_res[I]) * mmcc_res[I] / self._mpdenom[I]) for I in range(len(mmcc_res))]
+    if self._energies != []:
+        self._E_mmcc_mp.append(self._curr_energy + sum(mmcc_res_sq_over_mpdenom))
+        mmcc_res_sq_over_epstein_nesbet_denom = [np.real(np.conj(mmcc_res[I]) * mmcc_res[I] / (self._curr_energy - self._epstein_nesbet[I])) for I in range(len(mmcc_res))]
+        self._E_mmcc_en.append(self._curr_energy + sum(mmcc_res_sq_over_epstein_nesbet_denom))

--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -85,13 +85,12 @@ def compute_moment_energies(self):
 
     # The moments, i.e., residuals, are estimated by measuring the "residual" state a la SPQE
 
-    if hasattr(self, '_dt'):
-        dt = self._dt
-    else:
-        # not sure about this
-        dt = 0.001
+    if self._moment_dt is None:
+        print("WARNING: No value has been provided for the moment_dt variable required by the moment correction code!"
+              "\nProceeding with the default value of 0.001")
+        self._moment_dt = 0.001
 
-    self._eiH, self._eiH_phase = trotterize(self._qb_ham, factor= dt*(0.0 + 1.0j), trotter_number=self._trotter_number)
+    self._eiH, self._eiH_phase = trotterize(self._qb_ham, factor= self._moment_dt*(0.0 + 1.0j), trotter_number=self._trotter_number)
 
     # do U^dag e^iH U |Phi_o> = |Phi_res>
     U = self.ansatz_circuit()
@@ -102,7 +101,7 @@ def compute_moment_energies(self):
     qc_res.apply_circuit(self._eiH)
     qc_res.apply_circuit(U.adjoint())
 
-    res_coeffs = [i / dt for i in qc_res.get_coeff_vec()]
+    res_coeffs = [i / self._moment_dt for i in qc_res.get_coeff_vec()]
 
     mmcc_res = [res_coeffs[I] for I in self._mmcc_excitation_indices]
     mmcc_res_sq_over_mpdenom = [np.real(np.conj(mmcc_res[I]) * mmcc_res[I] / self._mpdenom[I]) for I in range(len(mmcc_res))]

--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -29,12 +29,10 @@ def construct_moment_space(self):
     nalpha = sum(self._ref[0::2])
     nbeta = sum(self._ref[1::2])
 
-    if self._max_moment_rank is None:
-        self._max_moment_rank = nalpha + nbeta
-    elif not isinstance(self._max_moment_rank, int) or self._max_moment_rank <= 0:
-        raise TypeError("The maximum moment rank must be a positive integer!")
+    if not isinstance(self._max_moment_rank, int) or self._max_moment_rank < 0:
+        raise TypeError("The maximum moment rank must be a non-negative integer!")
     elif self._max_moment_rank > nalpha + nbeta:
-        # WARNING: This step could be potetnially removed, if QForte gets methods
+        # WARNING: This step could be potetnially removed, if QForte allows for methods
         #          that violate particle number symmetry
         self._max_moment_rank = nalpha + nbeta
 

--- a/tests/test_moment_energy_corrections.py
+++ b/tests/test_moment_energy_corrections.py
@@ -1,0 +1,34 @@
+from pytest import approx
+from qforte import system_factory, UCCNPQE
+
+class TestNonIterativeEnergyCorrections:
+    def test_N2_uccsd_pqe(self):
+        # This is a regression test
+
+        to_angs = 0.529177210903
+    Rhh = 4
+    # R = 5.7467083952 * 10 /29
+    # R = 1.310011 * 18 / 10
+    R = 2.5
+
+    mol = system_factory(system_type = 'molecule',
+            build_type = 'psi4',
+            basis = 'sto-6g',
+            mol_geometry = [('N', (0, 0, 0)),
+                            ('N', (0, 0, 3))],
+            symmetry = 'd2h',
+            multiplicity = 1, # Only singlets will work with QForte
+            charge = 0,
+            num_frozen_docc = 4,
+            num_frozen_uocc = 0,
+            run_mp2=0,
+            run_ccsd=0,
+            run_cisd=0,
+            run_fci=0)
+
+    alg = UCCNPQE(mol, compact_excitations = True, diis_max_dim=5, max_moment_rank=4)
+    alg.run(pool_type='SD', opt_maxiter=60)
+
+    assert alg._Egs == approx(-108.48042111794851, abs=1.0e-12)
+    assert alg._E_mmcc_mp[0] == approx(-108.49099118292136, abs=1.0e-12)
+    assert alg._E_mmcc_en[0] == approx(-108.49255922885332, abs=1.0e-12)


### PR DESCRIPTION
## Description
Added non-iterative energy corrections based on the method of moments of coupled-cluster theory. So far, two types of corrections have been considered, the first using Moller-Plesset and the second Epstein-Nesbet denominators. These corrections are currently interfaced with all ansatz-dependent algorithms in QForte, namely, UCCNPQE, SPQE, UCCNVQE, and ADAPTVQE.

A test for the new functionality has been added.

## User Notes
- [x ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
