### PR TITLE
Fixed bug introduced in #182

### DIFF
--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -335,9 +335,9 @@ class SPQE(UCCPQE):
                     raise ValueError("Residual has imaginary component, something went wrong!!")
                 residuals.append(coeffs[self._reversed_excitation_dictionary[m]].real)
 
-            self._res_vec_norm = np.linalg.norm(residuals)
-            self._res_vec_evals += 1
-            self._res_m_evals += len(trial_amps)
+        self._res_vec_norm = np.linalg.norm(residuals)
+        self._res_vec_evals += 1
+        self._res_m_evals += len(trial_amps)
 
         return residuals
 


### PR DESCRIPTION
## Description
Fixes a bug in the count of residual vector and element evaluations introduced in #182 


## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
