### PR TITLE
Make JW transform give deterministic ordering of the qubit operators.…

### DIFF
--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -190,3 +190,7 @@ bool operator==(const Circuit& qc1, const Circuit& qc2)  {
         return false;
     }
 }
+
+bool operator < (const Circuit& qc1, const Circuit& qc2)  {
+    return qc1.str() < qc2.str();
+}

--- a/src/qforte/circuit.h
+++ b/src/qforte/circuit.h
@@ -63,8 +63,9 @@ class Circuit {
     std::vector<Gate> gates_;
 };
 
-// A eqivalence comparitor for Circuit class
+// A equivalence comparitor for Circuit class
 bool operator==(const Circuit& qc1, const Circuit& qc2);
+bool operator < (const Circuit& qc1, const Circuit& qc2);
 
 
 

--- a/src/qforte/circuit.h
+++ b/src/qforte/circuit.h
@@ -63,7 +63,6 @@ class Circuit {
     std::vector<Gate> gates_;
 };
 
-// A equivalence comparitor for Circuit class
 bool operator==(const Circuit& qc1, const Circuit& qc2);
 bool operator < (const Circuit& qc1, const Circuit& qc2);
 

--- a/src/qforte/qubit_operator.cc
+++ b/src/qforte/qubit_operator.cc
@@ -81,9 +81,9 @@ void QubitOperator::canonical_order() {
 
 void QubitOperator::simplify(bool combine_like_terms) {
     canonical_order();
-    std::unordered_map<Circuit, std::complex<double>> uniqe_trms;
+    std::map<Circuit, std::complex<double>> uniqe_trms;
     for (const auto& term : terms_) {
-        if ( uniqe_trms.find(term.second) == uniqe_trms.end() ) {
+        if (uniqe_trms.count(term.second) == 0) {
             uniqe_trms.insert(std::make_pair(term.second, term.first));
         } else {
             uniqe_trms[term.second] += term.first;
@@ -93,12 +93,12 @@ void QubitOperator::simplify(bool combine_like_terms) {
     if(combine_like_terms){
         for (const auto &uniqe_trm : uniqe_trms){
             if (std::abs(uniqe_trm.second) > 1.0e-12) {
-                terms_.push_back(std::make_pair(uniqe_trm.second, uniqe_trm.first));
+                terms_.emplace_back(uniqe_trm.second, uniqe_trm.first);
             }
         }
     } else {
         for (const auto &uniqe_trm : uniqe_trms){
-            terms_.push_back(std::make_pair(uniqe_trm.second, uniqe_trm.first));
+            terms_.emplace_back(uniqe_trm.second, uniqe_trm.first);
         }
     }
 }

--- a/tests/test_moment_energy_corrections.py
+++ b/tests/test_moment_energy_corrections.py
@@ -30,5 +30,5 @@ class TestNonIterativeEnergyCorrections:
     alg.run(pool_type='SD', opt_maxiter=60)
 
     assert alg._Egs == approx(-108.48042111794851, abs=1.0e-12)
-    assert alg._E_mmcc_mp[0] == approx(-108.49099118292136, abs=1.0e-12)
-    assert alg._E_mmcc_en[0] == approx(-108.49255922885332, abs=1.0e-12)
+    assert alg._E_mmcc_mp[0] == approx(-108.49099104714385, abs=1.0e-12)
+    assert alg._E_mmcc_en[0] == approx(-108.49255913211523, abs=1.0e-12)


### PR DESCRIPTION
… Matters for trotterize reproducibility.

## Description
A brief description of the goals accomplished by this PR

## User Notes
- [x] A bug was fixed that produced inconsistent orderings of quantum operators across machines when `QubitOperator.simplify()` was called. This may cause seventh digit changes to QForte computations, even with tight convergence.

## Checklist
- [x] Updated tests of changed features
- [x] Ready to go!
