### PR TITLE
Fixed seg fault line

### DIFF
--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -85,7 +85,7 @@ std::complex<double> Circuit::canonicalize_pauli_circuit() {
         if (first_gate_for_qubit) {
             s = gates_[i].gate_id();
         }
-        if(gates_[i].target() == gates_[i+1].target() && i + 1 != n_gates) {
+        if(i + 1 != n_gates && gates_[i].target() == gates_[i+1].target()) {
             // The upcoming gate also acts on this qubit, and it exists. Time to update s.
             const auto& qubit_update = m[std::make_pair(s, gates_[i+1].gate_id())];
             coeff *= qubit_update.first;


### PR DESCRIPTION
## Description
A segmentation fault sometimes occurs during get_qubit_operator() calls on my machine due to one line in circuit.cc.   This seems to fix it.

## User Notes
- [ ] Features added
  Repaired line in circuit.cc
- [N/A ] Changes to compilation (if any)

## Checklist
- [ N/A] Added/updated tests of new features
- [ N/A] Removed comments in input files
- [ N/A] Documented source code
- [ N/A] Checked for redundant headers/imports
- [ N/A] Checked for consistency in the formatting of the output file
- [ Y] Ready to go!
