### PR TITLE
Optimizing deterministic jw

### DIFF
--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -199,5 +199,19 @@ bool operator==(const Circuit& qc1, const Circuit& qc2)  {
 }
 
 bool operator < (const Circuit& qc1, const Circuit& qc2)  {
-    return qc1.str() < qc2.str();
+    if (qc1.size() != qc2.size()) {
+        return qc1.size() < qc2.size();
+    }
+    for (int k=0; k < qc1.size(); k++) {
+        if (qc1.gates()[k].target() != qc2.gates()[k].target()) {
+            return qc1.gates()[k].target() < qc2.gates()[k].target();
+        }
+        if (qc1.gates()[k].gate_id() != qc2.gates()[k].gate_id()) {
+            return qc1.gates()[k].gate_id() < qc2.gates()[k].gate_id();
+        }
+        if (qc1.gates()[k].control() != qc2.gates()[k].control()) {
+            return qc1.gates()[k].control() < qc2.gates()[k].control();
+        }
+    }
+    return false;
 }

--- a/src/qforte/qubit_operator.cc
+++ b/src/qforte/qubit_operator.cc
@@ -83,10 +83,11 @@ void QubitOperator::simplify(bool combine_like_terms) {
     canonical_order();
     std::map<Circuit, std::complex<double>> uniqe_trms;
     for (const auto& term : terms_) {
-        if (uniqe_trms.count(term.second) == 0) {
-            uniqe_trms.insert(std::make_pair(term.second, term.first));
+        auto it = uniqe_trms.find(term.second);
+        if (it == uniqe_trms.end()) {
+            uniqe_trms.insert(std::make_pair(std::move(term.second), term.first));
         } else {
-            uniqe_trms[term.second] += term.first;
+            it->second += term.first;
         }
     }
     terms_.clear();

--- a/tests/test_moment_energy_corrections.py
+++ b/tests/test_moment_energy_corrections.py
@@ -5,30 +5,29 @@ class TestNonIterativeEnergyCorrections:
     def test_N2_uccsd_pqe(self):
         # This is a regression test
 
-        to_angs = 0.529177210903
-    Rhh = 4
-    # R = 5.7467083952 * 10 /29
-    # R = 1.310011 * 18 / 10
-    R = 2.5
+        Rhh = 4
+        # R = 5.7467083952 * 10 /29
+        # R = 1.310011 * 18 / 10
+        R = 2.5
 
-    mol = system_factory(system_type = 'molecule',
-            build_type = 'psi4',
-            basis = 'sto-6g',
-            mol_geometry = [('N', (0, 0, 0)),
-                            ('N', (0, 0, 3))],
-            symmetry = 'd2h',
-            multiplicity = 1, # Only singlets will work with QForte
-            charge = 0,
-            num_frozen_docc = 4,
-            num_frozen_uocc = 0,
-            run_mp2=0,
-            run_ccsd=0,
-            run_cisd=0,
-            run_fci=0)
+        mol = system_factory(system_type = 'molecule',
+                build_type = 'psi4',
+                basis = 'sto-6g',
+                mol_geometry = [('N', (0, 0, 0)),
+                                ('N', (0, 0, 3))],
+                symmetry = 'd2h',
+                multiplicity = 1, # Only singlets will work with QForte
+                charge = 0,
+                num_frozen_docc = 4,
+                num_frozen_uocc = 0,
+                run_mp2=0,
+                run_ccsd=0,
+                run_cisd=0,
+                run_fci=0)
 
-    alg = UCCNPQE(mol, compact_excitations = True, diis_max_dim=5, max_moment_rank=4)
-    alg.run(pool_type='SD', opt_maxiter=60)
+        alg = UCCNPQE(mol, compact_excitations = True, diis_max_dim=5, max_moment_rank=4)
+        alg.run(pool_type='SD', opt_maxiter=60)
 
-    assert alg._Egs == approx(-108.48042111794851, abs=1.0e-12)
-    assert alg._E_mmcc_mp[0] == approx(-108.49099104714385, abs=1.0e-12)
-    assert alg._E_mmcc_en[0] == approx(-108.49255913211523, abs=1.0e-12)
+        assert alg._Egs == approx(-108.48042111794851, abs=1.0e-12)
+        assert alg._E_mmcc_mp[0] == approx(-108.49099104585895, abs=1.0e-12)
+        assert alg._E_mmcc_en[0] == approx(-108.49255913217682, abs=1.0e-12)


### PR DESCRIPTION
## Description
Modified the "<" comparison function for the `Circuit` class to speed up the `simplify` function for the `QubitOperator` class. Jonathon's hypothesis was correct; converting to strings was time consuming. Based on various tests, the new code significantly speeds up the deterministic JW transform.

I modified the expected results for one of the tests to reflect the new ordering in the deterministic JW.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
