### PR TITLE
Fixed bug in moment energy correction

### DIFF
--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -90,7 +90,7 @@ def compute_moment_energies(self):
               "\nProceeding with the default value of 0.001")
         self._moment_dt = 0.001
 
-    self._eiH, _ = trotterize(self._qb_ham, factor= self._moment_dt*(0.0 + 1.0j), trotter_number=self._trotter_number)
+    _eiH, _ = trotterize(self._qb_ham, factor= self._moment_dt*(0.0 + 1.0j), trotter_number=self._trotter_number)
 
     # do U^dag e^iH U |Phi_o> = |Phi_res>
     U = self.ansatz_circuit()
@@ -98,7 +98,7 @@ def compute_moment_energies(self):
     qc_res = qf.Computer(self._nqb)
     qc_res.apply_circuit(self._Uprep)
     qc_res.apply_circuit(U)
-    qc_res.apply_circuit(self._eiH)
+    qc_res.apply_circuit(_eiH)
     qc_res.apply_circuit(U.adjoint())
 
     res_coeffs = [i / self._moment_dt for i in qc_res.get_coeff_vec()]


### PR DESCRIPTION
## Description
Fixed a bug in the moment energy correction code. In the original version of the code and when running SPQE, the moment correction code would overwrite the self._eiH attribute of SPQE. Now this is fixed.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
