### PR TITLE
Added function to compute matrix elements of operators

### DIFF
--- a/src/qforte/utils/__init__.py
+++ b/src/qforte/utils/__init__.py
@@ -9,3 +9,4 @@ from .qubit_tapering import *
 from .spin_operators import *
 from .compact_excitation_circuits import *
 from .symmetry_analysis import *
+from .compute_matrix_element import *

--- a/src/qforte/utils/compute_matrix_element.py
+++ b/src/qforte/utils/compute_matrix_element.py
@@ -1,0 +1,42 @@
+import qforte as qf
+
+def compute_operator_matrix_element(n_qubit, U_bra, U_ket, QOp=None):
+    """
+    This function computes expressions of the form:
+
+    <Psi_bra| QOp | Psi_ket> = <0| U_bra^dagger QOp U_ket |0>.
+
+    Note that, if required, the U_bra and U_ket circuits should
+    contain the X strings to convert the <0| and |0> states to
+    the desired Slater determinants.
+
+    Arguments
+    =========
+
+    n_qubit: int
+        Number of qubits of the system.
+
+    U_bra: Circuit object
+        The quantum circuit that defines |Psi_bra> = U_bra |0>.
+        The adjoint of U_bra is constructed by this function.
+
+    U_ket: Circuit object
+        The quantum circuit that defines |Psi_ket> = U_ket |0>.
+
+    QOp: QubitOperator object or None
+        The operator whose matrix element we are computing.
+        If QOp is None, then the <Psi_bra|Psi_ket> overlap
+        is computed.
+
+    Returns
+    =======
+
+    The value of the desired matrix element.
+    """
+
+    comp = qf.Computer(n_qubit)
+    comp.apply_circuit(U_ket)
+    if QOp is not None:
+        comp.apply_operator(QOp)
+    comp.apply_circuit(U_bra.adjoint())
+    return comp.get_coeff_vec()[0]

--- a/tests/test_compute_matrix_element.py
+++ b/tests/test_compute_matrix_element.py
@@ -1,0 +1,50 @@
+from pytest import approx
+from qforte import system_factory, Circuit, gate, compute_operator_matrix_element
+import numpy as np
+
+class TestComputeMatrixElement:
+    def test_H2_Hmat_diagonilaztion(self):
+
+        to_angs = 0.529177210903
+
+        mol = system_factory(system_type = 'molecule',
+                build_type = 'psi4',
+                basis = 'sto-6g',
+                mol_geometry = [('H', (0, 0, 0)),
+                                ('H', (0, 0, 1.401 * to_angs))],
+                symmetry = 'd2h',
+                multiplicity = 1,
+                charge = 0,
+                num_frozen_docc = 0,
+                num_frozen_uocc = 0,
+                run_mp2=1,
+                run_ccsd=0,
+                run_cisd=0,
+                run_fci=1)
+
+        circ_hf = Circuit()
+        for i in range(2):
+            circ_hf.add(gate('X', i))
+
+        circ_doubles = Circuit()
+        for i in range(2,4):
+            circ_doubles.add(gate('X', i))
+
+
+        S_mat = np.zeros((2,2))
+        H_mat = np.zeros((2,2))
+
+        for i, det_i in enumerate([circ_hf, circ_doubles]):
+            for j, det_j in enumerate([circ_hf, circ_doubles]):
+                S_mat[i,j] = np.real(compute_operator_matrix_element(mol.hamiltonian.num_qubits(), det_i, det_j))
+                H_mat[i,j] = np.real(compute_operator_matrix_element(mol.hamiltonian.num_qubits(), det_i, det_j, mol.hamiltonian))
+
+        assert S_mat[0,0] == 1
+        assert S_mat[0,1] == 0
+        assert S_mat[1,0] == 0
+        assert S_mat[1,1] == 1
+
+        eig_val, _ = np.linalg.eigh(H_mat)
+
+        assert eig_val[0] == approx(mol.fci_energy, abs=1.0e-12)
+        assert eig_val[1] == approx(0.47298335127441565, abs=1.0e-12)


### PR DESCRIPTION
## Description
Added a function to compute matrix elements of the form:

<Psi_bra| QOp |Psi_ket> = <0| U_bra^dagger QOp U_ket |0>.

If no QOp operator is provided, the function returns the <Psi_bra | Psi_ket> overlap.

I also added a test and it passes successfully.

## User Notes
- [x ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
