### PR TITLE
Created function that returns the labels of the irreps of a given point group

### DIFF
--- a/src/qforte/adapters/molecule_adapters.py
+++ b/src/qforte/adapters/molecule_adapters.py
@@ -140,7 +140,7 @@ def create_psi_mol(**kwargs):
     del orbitals
 
     point_group = p4_mol.symmetry_from_input().lower()
-    irreps = p4_mol.irrep_labels()
+    irreps = qforte.irreps_of_point_groups(point_group)
     orb_irreps = [irreps[i] for i in orb_irreps_to_int]
 
     # If frozen_core > 0, compute the frozen core energy and transform one-electron integrals

--- a/src/qforte/utils/point_groups.py
+++ b/src/qforte/utils/point_groups.py
@@ -15,10 +15,6 @@ def irreps_of_point_groups(point_group):
     """
 
     point_group = point_group.lower()
-    groups = ['c1', 'c2', 'ci', 'cs', 'd2', 'c2h', 'c2v', 'd2h']
-    if point_group not in groups:
-        raise ValueError('The given point group is not supported. Choose one of:\n{0}'.format(groups))
-
     point_group_to_irreps = {'c1'  : ['A'],
                              'c2'  : ['A', 'B'],
                              'ci'  : ['Ag', 'Au'],
@@ -28,7 +24,10 @@ def irreps_of_point_groups(point_group):
                              'c2v' : ['A1', 'A2', 'B1', 'B2'],
                              'd2h' : ['Ag', 'B1g', 'B2g', 'B3g', 'Au', 'B1u', 'B2u', 'B3u']}
 
-    return point_group_to_irreps[point_group]
+    try:
+        return point_group_to_irreps[point_group]
+    except KeyError:
+        raise ValueError(f'The given point group is not supported. Choose one of:\n{", ".join(point_group_to_irreps.keys())}')
 
 def char_table(point_group):
     """

--- a/src/qforte/utils/point_groups.py
+++ b/src/qforte/utils/point_groups.py
@@ -8,6 +8,28 @@ Currently, this module pertains only to molecular
 objects with "build_type = 'psi4'".
 """
 
+def irreps_of_point_groups(point_group):
+    """
+    Function that returns the irreps of a given point group,
+    using the Cotton ordering.
+    """
+
+    point_group = point_group.lower()
+    groups = ['c1', 'c2', 'ci', 'cs', 'd2', 'c2h', 'c2v', 'd2h']
+    if point_group not in groups:
+        raise ValueError('The given point group is not supported. Choose one of:\n{0}'.format(groups))
+
+    point_group_to_irreps = {'c1'  : ['A'],
+                             'c2'  : ['A', 'B'],
+                             'ci'  : ['Ag', 'Au'],
+                             'cs'  : ['Ap', 'App'],
+                             'd2'  : ['A', 'B1', 'B2', 'B3'],
+                             'c2h' : ['Ag', 'Bg', 'Au', 'Bu'],
+                             'c2v' : ['A1', 'A2', 'B1', 'B2'],
+                             'd2h' : ['Ag', 'B1g', 'B2g', 'B3g', 'Au', 'B1u', 'B2u', 'B3u']}
+
+    return point_group_to_irreps[point_group]
+
 def char_table(point_group):
     """
     Function that prints the character table of a chosen point group.

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -2,7 +2,7 @@ import pytest
 from pytest import approx
 from unittest.mock import patch
 from io import StringIO
-from qforte import system_factory, char_table, UCCNVQE, ADAPTVQE, UCCNPQE
+from qforte import system_factory, char_table, irreps_of_point_groups, UCCNVQE, ADAPTVQE, UCCNPQE
 
 class TestPointGroupSymmetry():
 
@@ -151,3 +151,21 @@ class TestPointGroupSymmetry():
             assert Egs == approx(Efci, abs=1.0e-10)
 
             assert len(alg._pool_obj) == t_ops[count]
+
+    def test_point_group_to_irreps(self):
+
+        groups = ['c1', 'c2', 'ci', 'cs', 'd2', 'c2h', 'c2v', 'd2h']
+        irreps = [['A'],
+                  ['A', 'B'],
+                  ['Ag', 'Au'],
+                  ['Ap', 'App'],
+                  ['A', 'B1', 'B2', 'B3'],
+                  ['Ag', 'Bg', 'Au', 'Bu'],
+                  ['A1', 'A2', 'B1', 'B2'],
+                  ['Ag', 'B1g', 'B2g', 'B3g', 'Au', 'B1u', 'B2u', 'B3u']]
+
+        for idx, group in enumerate(groups):
+            assert irreps_of_point_groups(group) == irreps[idx]
+
+        with pytest.raises(ValueError, match='The given point group is not supported. Choose one of:\nc1, c2, ci, cs, d2, c2h, c2v, d2h'):
+            irreps_of_point_groups('d3h')


### PR DESCRIPTION
## Description
Created a function that returns the labels of the irreps of a given point group. Instead of extracting the labels from Psi4, we get them from the aforementioned function. This is a step toward reading symmetry information from external JSON files.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ x] Ready to go!
