### PR TITLE
Debug mult_coeff method in SQOP

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -43,6 +43,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("add_term", &SQOperator::add_term)
         .def("add_op", &SQOperator::add_op)
         .def("set_coeffs", &SQOperator::set_coeffs)
+        .def("mult_coeffs", &SQOperator::mult_coeffs)
         .def("terms", &SQOperator::terms)
         .def("canonical_order", &SQOperator::canonical_order)
         .def("simplify", &SQOperator::simplify)

--- a/src/qforte/sq_op_pool.cc
+++ b/src/qforte/sq_op_pool.cc
@@ -366,11 +366,6 @@ void SQOpPool::fill_pool(std::string pool_type){
 
                 temp1.simplify();
 
-                std::complex<double> temp1_norm(0.0, 0.0);
-                for (const auto& term : temp1.terms()){
-                    temp1_norm += std::norm(std::get<0>(term));
-                }
-                temp1.mult_coeffs(1.0/std::sqrt(temp1_norm));
                 add_term(1.0, temp1);
             }
         }
@@ -470,8 +465,8 @@ void SQOpPool::fill_pool(std::string pool_type){
                         for (const auto& term : temp2b.terms()){
                             temp2b_norm += std::norm(std::get<0>(term));
                         }
-                        temp2a.mult_coeffs(1.0/std::sqrt(temp2a_norm));
-                        temp2b.mult_coeffs(1.0/std::sqrt(temp2b_norm));
+                        temp2a.mult_coeffs(std::sqrt(2.0/temp2a_norm));
+                        temp2b.mult_coeffs(std::sqrt(2.0/temp2b_norm));
 
                         if(temp2a.terms().size() > 0){
                             add_term(1.0, temp2a);

--- a/src/qforte/sq_operator.cc
+++ b/src/qforte/sq_operator.cc
@@ -26,7 +26,7 @@ void SQOperator::set_coeffs(const std::vector<std::complex<double>>& new_coeffs)
 }
 
 void SQOperator::mult_coeffs(const std::complex<double>& multiplier) {
-    for (auto term : terms_){
+    for (auto& term : terms_){
         std::get<0>(term) *= multiplier;
     }
 }

--- a/tests/test_sq_pool.py
+++ b/tests/test_sq_pool.py
@@ -1,3 +1,5 @@
+#import numpy as np
+from pytest import approx
 from qforte import SQOpPool, SQOperator
 
 class TestSqPool:
@@ -16,3 +18,14 @@ class TestSqPool:
         for coefficient, operator in pool:
             assert isinstance(coefficient, complex)
             assert isinstance(operator, SQOperator)
+
+    def test_sa_sd_pool(self):
+        pool = SQOpPool()
+        pool.set_orb_spaces([1, 1, 0, 0, 0, 0])
+        pool.fill_pool("sa_SD")
+
+        for pool_term in pool.terms():
+            coeff_norm = 0
+            for sq_op_term in pool_term[1].terms():
+                coeff_norm += sq_op_term[0] ** 2
+            assert coeff_norm == approx(2, abs=1.0e-15)

--- a/tests/test_sqop.py
+++ b/tests/test_sqop.py
@@ -1,0 +1,21 @@
+from qforte import SQOperator
+
+class TestSQOp:
+    def test_mult_coeffs(self):
+        # In this test, we confirm that the method `mult_coeffs` works 
+        # to multiply each coefficient with one identical number
+
+        sq_op = SQOperator()
+
+        sq_op.add_term( 1, [0, 1], [2, 3])
+        sq_op.add_term(-1, [2, 3], [0, 1])
+        sq_op.mult_coeffs(0.5 + 0.5j)
+
+        terms = sq_op.terms()
+
+        assert len(terms) == 2
+        assert terms[0][1] == [0, 1]
+        assert terms[0][2] == [2, 3]
+
+        assert terms[0][0] == 0.5 + 0.5j
+        assert terms[1][0] == -0.5 - 0.5j


### PR DESCRIPTION
## Description
Fixed a bug in `SQOperator::mult_coeffs`: Updated the original for-loop using reference, so that the values of the class member `terms_` will be acted upon, instead of creating a copy, and linked this function to Python side in `bindings.cc`.

Fixed the normalization in spin-adapted SD pool in `SQOpPool` object where the `mult_coeffs` was misused.

Reminder: Needs re-compilation after pulling to the local.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x] Ready to go!
