### PR TITLE
Disabled compact circuits for sa_SD pool, not yet implemented

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -258,6 +258,8 @@ class AnsatzAlgorithm(Algorithm):
         """
 
         if self._pool_type in {'sa_SD', 'GSD', 'SD', 'SDT', 'SDTQ', 'SDTQP', 'SDTQPH'}:
+            if self._pool_type == 'sa_SD' and self._compact_excitations:
+                raise ValueError('Compact excitation circuits not yet implemented for sa_SD operator pool.')
             self._pool_obj = qf.SQOpPool()
             if hasattr(self._sys, 'orb_irreps_to_int'):
                 self._pool_obj.set_orb_spaces(self._ref, self._sys.orb_irreps_to_int)


### PR DESCRIPTION
## Description
Disabled the use of compact circuits for the sa_SD operator pool. This functionality is not yet implemented.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x] Ready to go!
