### PR TITLE
Fix QPE after SciPy API Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ conda activate qforte_env
 #### install required packages:
 ```bash
 conda install psi4 -c psi4
-conda install scipy
+conda install scipy>=1.11
 ```
 
 Installation (For Development)

--- a/src/qforte/qpea/qpe.py
+++ b/src/qforte/qpea/qpe.py
@@ -99,8 +99,10 @@ class QPE(Algorithm):
         E_l = -2 * np.pi * (self._final_phase + self._guess_periods - 0) / t
         E_qpe = E_l if abs(E_l - guess_energy) < abs(E_u - guess_energy) else E_u
 
+        print(f"{self._phases=}")
         res = stats.mode(np.asarray(self._phases))
-        self._mode_phase = res.mode[0]
+        print(f"{res.mode=}")
+        self._mode_phase = res.mode
         E_u = -2 * np.pi * (self._mode_phase + self._guess_periods - 1) / t
         E_l = -2 * np.pi * (self._mode_phase + self._guess_periods - 0) / t
         self._mode_energy = E_l if abs(E_l - guess_energy) < abs(E_u - guess_energy) else E_u

--- a/src/qforte/qpea/qpe.py
+++ b/src/qforte/qpea/qpe.py
@@ -99,9 +99,7 @@ class QPE(Algorithm):
         E_l = -2 * np.pi * (self._final_phase + self._guess_periods - 0) / t
         E_qpe = E_l if abs(E_l - guess_energy) < abs(E_u - guess_energy) else E_u
 
-        print(f"{self._phases=}")
         res = stats.mode(np.asarray(self._phases))
-        print(f"{res.mode=}")
         self._mode_phase = res.mode
         E_u = -2 * np.pi * (self._mode_phase + self._guess_periods - 1) / t
         E_l = -2 * np.pi * (self._mode_phase + self._guess_periods - 0) / t


### PR DESCRIPTION
## Description
SciPy changed the API of their `stats.mode` function but didn't document it. This function adjusts our use of `stats.mode` so as not to raise an error. I have no idea what version first contained the change.

## Checklist
- [x] QPE tests pass again
- [x] Ready to go!
