### PR TITLE
Unpin pybind11 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ set(SOURCE_DIR "src/qforte")
 include_directories(${SOURCE_DIR})
 
 # Generate Python module
-add_subdirectory(lib/pybind11)
+find_package(pybind11 CONFIG REQUIRED)
 add_subdirectory(lib/fmt)
 pybind11_add_module(qforte ${SOURCES} "${SOURCE_DIR}/bindings.cc"
     "${SOURCE_DIR}/helpers.cc"

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ name: forte
 dependencies:
     - python=3.10
     - pip>=19.0
+    - pybind11
     - cmake
     - numpy
     - scipy


### PR DESCRIPTION
## Description
Unpin the pb11 version. We can now grab it from the environment, typically `conda`.

## User Notes
- [x] pybind now can (and needs to) be supplied  by the user. The existing compile instructions will handle this automatically.

## Checklist
- [x] Ready to go!
