### PR TITLE
Temporary fix for failing checks on github

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,11 +13,6 @@ jobs:
       with:
         submodules: 'true'    
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.10'
-
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory
@@ -25,10 +20,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda create -n qforte_env python=3.10
-        conda activate qforte_env
-        conda install psi4=1.8.2 -c conda-forge/label/libint_dev -c conda-forge
-        conda install pytest pybind11
+        conda env update --file environment.yml --name base
 
     - name: Compile
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         conda env update --file environment.yml --name base
-        conda install psi4 -c psi4/label/dev
+        conda install psi4=1.8.2 -c conda-forge/label/libint_dev -c conda-forge
 
     - name: Compile
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -13,6 +13,9 @@ jobs:
       with:
         submodules: 'true'    
 
+    - name: Install lcov
+      run: sudo apt-get update && sudo apt-get install -y lcov
+
     - name: Add conda to system path
       run: |
         # $CONDA is an environment variable pointing to the root of the miniconda directory

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -25,8 +25,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        #conda env update --file environment.yml --name base
+        conda create -n qforte_env python=3.10
+        conda activate qforte_env
         conda install psi4=1.8.2 -c conda-forge/label/libint_dev -c conda-forge
+        conda install pytest pybind11
 
     - name: Compile
       run: |

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        conda env update --file environment.yml --name base
+        #conda env update --file environment.yml --name base
         conda install psi4=1.8.2 -c conda-forge/label/libint_dev -c conda-forge
 
     - name: Compile

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: qforte_env
 
 channels:
     - defaults
+    - conda-forge/label/libint_dev
     - conda-forge
 
 dependencies:
@@ -10,4 +11,4 @@ dependencies:
     - pybind11
     - yaml
     - pytest
-    - psi4=1.8.2=*=*conda-forge/label/libint_dev
+    - psi4=1.8.2

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,13 @@
-name: forte
+name: qforte_env
+
+channels:
+    - defaults
+    - conda-forge
 
 dependencies:
-    - python=3.10
+    - python>=3.10
     - pip>=19.0
     - pybind11
-    - cmake
-    - numpy
-    - scipy
-    - boost
     - yaml
     - pytest
-    - conda-forge::lcov
+    - psi4=1.8.2=*=*conda-forge/label/libint_dev


### PR DESCRIPTION
## Description
There seems to be an issue with the latest Psi4 release on conda. As a result, all checks fail on GitHub. Switching to the previous release seems to fix the problem. This is a temporary solution and once the Psi4 issue is resolved, we can switch to its latest version again.

I had to do some additional modifications to the workflows and environment.yml file. Eventually, we can modify the installation instructions by using the yml file to create the qforte environment and install all dependencies.

All checks on GitHub have successfully passed!

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
