### PR TITLE
Fixed occasional failing of test_circuit_to_latex

### DIFF
--- a/tests/test_circuit_to_latex.py
+++ b/tests/test_circuit_to_latex.py
@@ -2,6 +2,9 @@ import pytest
 import qforte as qf
 import os
 
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+reference_tex = os.path.join(THIS_DIR, 'circuit_to_latex_reference.tex')
+
 class TestCircuitToLatex:
     def test_circ2latex_regression(self):
 
@@ -29,7 +32,7 @@ class TestCircuitToLatex:
 
         with open("circuit_to_latex_generated.tex", "r") as generated_file:
             generated_content = generated_file.read()
-        with open("circuit_to_latex_reference.tex", "r") as reference_file:
+        with open(reference_tex, "r") as reference_file:
             reference_content = reference_file.read()
         assert generated_content == reference_content
 


### PR DESCRIPTION
## Description
The test_circuit_to_latex would fail if run outside the test folder, since the reference tex file could not be found. Now the test can be run from anywhere and finish successfully.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
