### PR TITLE
Removed redundant gates and updated gate tests

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -244,7 +244,7 @@ PYBIND11_MODULE(qforte, m) {
 
             // only single qubit gates accept this synthax
             auto vec = {"X",  "Y", "Z", "H", "R", "Rx",  "Ry",
-                        "Rz", "V", "S", "T", "I", "Rzy", "rU1"};
+                        "Rz", "V", "S", "T", "I"};
             if (std::find(vec.begin(), vec.end(), type) != vec.end()) {
                 return make_gate(type, target, target, parameter.real());
             }
@@ -267,7 +267,7 @@ PYBIND11_MODULE(qforte, m) {
             // target and control
             if (target == control) {
                 auto vec2 = {
-                    "X", "Y", "Z", "H", "V", "S", "T", "I", "Rzy",
+                    "X", "Y", "Z", "H", "V", "S", "T", "I",
                 };
                 if (std::find(vec2.begin(), vec2.end(), type) != vec2.end()) {
                     return make_gate(type, target, control, 0.0);

--- a/src/qforte/computer.cc
+++ b/src/qforte/computer.cc
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <functional>
 #include <stdexcept>
+#include <cmath>
 
 #include "fmt/format.h"
 
@@ -153,7 +154,7 @@ std::vector<double> Computer::measure_circuit(const Circuit& qc, size_t n_measur
             Gate temp = make_gate("H", target_qubit, target_qubit);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id == "Y") {
-            Gate temp = make_gate("Rzy", target_qubit, target_qubit);
+            Gate temp = make_gate("Rx", target_qubit, target_qubit, M_PI / 2);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id != "I") {
             // // // std::cout<<'unrecognized gate in operator!'<<std::endl;
@@ -233,7 +234,7 @@ std::vector<std::vector<int>> Computer::measure_readouts(const Circuit& qc, size
             Gate temp = make_gate("H", target_qubit, target_qubit);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id == "Y") {
-            Gate temp = make_gate("Rzy", target_qubit, target_qubit);
+            Gate temp = make_gate("Rx", target_qubit, target_qubit, M_PI / 2);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id != "I") {
             // // // std::cout<<'unrecognized gate in operator!'<<std::endl;
@@ -289,7 +290,7 @@ double Computer::perfect_measure_circuit(const Circuit& qc) {
             Gate temp = make_gate("H", target_qubit, target_qubit);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id == "Y") {
-            Gate temp = make_gate("Rzy", target_qubit, target_qubit);
+            Gate temp = make_gate("Rx", target_qubit, target_qubit, M_PI / 2);
             QubitBasis_rotator.add_gate(temp);
         } else if (gate_id != "I") {
             // std::cout<<'unrecognized gate in operator!'<<std::endl;

--- a/src/qforte/gate.cc
+++ b/src/qforte/gate.cc
@@ -173,11 +173,11 @@ GateType Gate::mapLabelToType(const std::string& label_) {
         {"H", GateType::H}, {"R", GateType::R}, {"Rx", GateType::Rx},
         {"Ry", GateType::Ry}, {"Rz", GateType::Rz}, {"V", GateType::V},
         {"S", GateType::S}, {"T", GateType::T}, {"I", GateType::I},
-        {"Rzy", GateType::Rzy}, {"rU1", GateType::rU1}, {"A", GateType::A},
+        {"A", GateType::A},
         {"CNOT", GateType::cX}, {"cX", GateType::cX}, {"aCNOT", GateType::acX},
         {"acX", GateType::acX}, {"cY", GateType::cY}, {"cZ", GateType::cZ},
         {"cR", GateType::cR}, {"cV", GateType::cV}, {"cRz", GateType::cRz},
-        {"SWAP", GateType::SWAP}, {"rU2", GateType::rU2}
+        {"SWAP", GateType::SWAP}
     };
 
     auto it = labelToType.find(label_);

--- a/src/qforte/gate.h
+++ b/src/qforte/gate.h
@@ -18,7 +18,7 @@ class SparseVector;
 
 /// useful for type safety and efficient comparisons
 enum class GateType {
-    X, Y, Z, H, R, Rx, Ry, Rz, V, S, T, I, Rzy, rU1, A, cX, acX, cY, cZ, cR, cV, cRz, SWAP, rU2, Undefined
+    X, Y, Z, H, R, Rx, Ry, Rz, V, S, T, I, A, cX, acX, cY, cZ, cR, cV, cRz, SWAP, Undefined
 };
 
 /// alias for a 4 x 4 complex matrix stored as an array of arrays

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -106,24 +106,6 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             };
             return Gate(type, target, control, gate);
         }
-        if (type == "Rzy") {
-            std::complex<double> c = 1.0 / std::sqrt(2.0);
-            std::complex<double> c_i = onei / std::sqrt(2.0);
-            std::complex<double> gate[4][4]{
-                {+c_i, +c},
-                {+c, +c_i},
-            };
-            return Gate(type, target, control, gate);
-        }
-        if (type == "rU1") {
-            std::complex<double> a = std::cos(parameter);
-            std::complex<double> b = std::sin(parameter);
-            std::complex<double> gate[4][4]{
-                {+a, -b},
-                {+b, +a},
-            };
-            return Gate(type, target, control, gate, std::make_pair(parameter, true));
-        }
 
     } else {
         if (type == "A") {
@@ -216,17 +198,6 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
                 {0.0, 0.0, 0.0, 1.0},
             };
             return Gate(type, target, control, gate);
-        }
-        if (type == "rU2") {
-            std::complex<double> a = std::cos(parameter);
-            std::complex<double> b = std::sin(parameter);
-            std::complex<double> gate[4][4]{
-                {+a, -b, 0.0, 0.0},
-                {+b, +a, 0.0, 0.0},
-                {0.0, 0.0, +a, -b},
-                {0.0, 0.0, +b, +a},
-            };
-            return Gate(type, target, control, gate, std::make_pair(parameter, true));
         }
     }
     // If you reach this section then the gate type is not implemented or it is invalid.

--- a/src/qforte/utils/exponentiate.py
+++ b/src/qforte/utils/exponentiate.py
@@ -43,8 +43,8 @@ def exponentiate_pauli_string(coefficient, term, Use_cRz=False, ancilla_idx=None
             to_z.add(qforte.gate('H', target, control))
             to_original.add(qforte.gate('H', target, control))
         elif (id == 'Y'):
-            to_z.add(qforte.gate('Rzy', target, control))
-            to_original.add(qforte.gate('Rzy', target, control))
+            to_z.add(qforte.gate('Rx', target, control, np.pi/2))
+            to_original.add(qforte.gate('Rx', target, control, -np.pi/2))
         elif (id == 'I'):
             continue
 

--- a/tests/test_comprehensive_gate.py
+++ b/tests/test_comprehensive_gate.py
@@ -18,7 +18,7 @@ def generic_test_circ_vec_builder(qb_list, id):
     for i, pair in enumerate(ct_lst):
         t = pair[0]
         c = pair[1]
-        if(id in ['A', 'rU2', 'cR', 'cRz']):
+        if(id in ['A', 'cR', 'cRz']):
             circ_vec_ct[i].add(gate(id, t, c, 3.17*t*c))
             circ_vec_tc[i].add(gate(id, c, t, 1.41*t*c))
 
@@ -59,7 +59,7 @@ def circuit_tester(prep, test_circ):
 
 class TestComprehensiveGates:
     def test_gates(self):
-        gate_ids = ['cV', 'cX', 'acX', 'cY', 'cZ', 'cR', 'cRz', 'SWAP', 'A', 'rU2']
+        gate_ids = ['cV', 'cX', 'acX', 'cY', 'cZ', 'cR', 'cRz', 'SWAP', 'A']
 
         for id in gate_ids:
             circ_tc, circ_ct = generic_test_circ_vec_builder(ct_lst, id)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -259,7 +259,7 @@ class TestGates:
         gate1 = gate('X',0)
         assert gate1.nqubits() == 1
         assert gate1.gate_id() == 'X'
-        assert gate1.has_parameter() == False 
+        assert gate1.has_parameter() == False
         assert gate1.parameter() == None
         with pytest.raises(ValueError):
             gate1.update_parameter(1.0)
@@ -302,15 +302,15 @@ class TestGates:
             gate2 = gate1.adjoint()
             assert gate1 == gate2
 
-        # 1-qubit non-self-adjoint gates   
-        gates = ['V','S','T','Rzy']
+        # 1-qubit non-self-adjoint gates
+        gates = ['V','S','T']
         for g in gates:
             gate1 = gate(g,0)
             gate2 = gate1.adjoint()
             assert gate1 != gate2
 
         # 1-qubit parameterized non-self-adjoint gates
-        gates = ['R','Rx','Ry','Rz','rU1']
+        gates = ['R','Rx','Ry','Rz']
         for g in gates:
             gate1 = gate(g,0,0.5)
             gate2 = gate1.adjoint()
@@ -329,10 +329,10 @@ class TestGates:
         for g in gates:
             gate1 = gate(g,0,1)
             gate2 = gate1.adjoint()
-            assert gate1 != gate2            
+            assert gate1 != gate2
 
         # 2-qubit parameterized non-self-adjoint gates
-        gates = ['cR','cRz','rU2']
+        gates = ['cR','cRz']
         for g in gates:
             gate1 = gate(g,0,1,0.5)
             gate2 = gate1.adjoint()
@@ -382,15 +382,6 @@ class TestGates:
         assert Rzadj.parameter() == approx(-0.7, abs=1.0e-16)
         Rzm = gate('Rz',0,-0.7)
         assert Rzadj == Rzm
-
-        # test the rU1 gate
-        rU1 = gate('rU1',0,0.7)
-        assert rU1.has_parameter() is True
-        assert rU1.parameter() == approx(0.7, abs=1.0e-16)
-        rU1adj = rU1.adjoint()
-        assert rU1adj.parameter() == approx(-0.7, abs=1.0e-16)
-        rU1m = gate('rU1',0,-0.7)
-        assert rU1adj == rU1m
 
         # test the cR gate
         cR = gate('cR',0,1,0.7)


### PR DESCRIPTION
## Description
The redundant gates included: Rzy, rU1, and rU2. The purpose of the Rzy gate was to rotate between the Z and Y computational bases. However, the same can be accomplished with the Rx(pi/2) gate. The rU1 gate was equivalent to Ry(2 * theta). The rU2 gate was equal to rU1 \otimes I.

The redundant gates have been removed and the same is true for their corresponding test cases.

Another possible candidate is the A gate (Givens rotation), which can be implemented using standard Ry and CNOT gates. This needs some further consideration.

All tests pass successfully.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
