### PR TITLE
Simplification of T, S, Z, and R phase gates added.

### DIFF
--- a/src/qforte/circuit.h
+++ b/src/qforte/circuit.h
@@ -96,6 +96,10 @@ class Circuit {
   private:
     /// the list of gates
     std::vector<Gate> gates_;
+
+    /// helper functions for simplify
+    double get_phase_gate_parameter(const Gate& gate);
+    double simplify_phase_1qubit_gates(const Gate& gate1, const Gate& gate2);
 };
 
 bool operator==(const Circuit& qc1, const Circuit& qc2);

--- a/src/qforte/gate.cc
+++ b/src/qforte/gate.cc
@@ -117,6 +117,15 @@ Gate Gate::adjoint() const {
     // if the gate is self-adjoint then we return the gate itself
     if (self_adjoint) {
         return *this;
+    }
+
+    // To facilitate circuit simplification, the adjoints of S and T are expressed
+    // in terms of the R phase gate.
+    
+    if (type_ == GateType::T) {
+        return Gate("R", target_, control_, adj_gate, std::make_pair(-M_PI / 4, true));
+    } else if (type_ == GateType::S) {
+         return Gate("R", target_, control_, adj_gate, std::make_pair(-M_PI / 2, true));
     } else {
         // check if label_ is of the form adj(x) and if it is then return Gate(x)
         if (label_.size() > 4 and label_.substr(0, 4) == "adj(" and label_.back() == ')') {
@@ -248,6 +257,13 @@ std::pair<bool, int> evaluate_gate_interaction(const Gate& gate1, const Gate& ga
     int product_nqubits = num_qubits_gate1 * num_qubits_gate2;
 
     if (product_nqubits == 1) {
+        if (phase_1qubit_gates.find(gate1.gate_type()) != phase_1qubit_gates.end() && phase_1qubit_gates.find(gate2.gate_type()) != phase_1qubit_gates.end()) {
+            if (gate1.gate_type() == gate2.gate_type()) {
+                return {true, 1};
+            } else {
+                return {true, 3};
+            }
+        }
         std::pair<GateType, GateType> pairGateType = std::make_pair(gate1.gate_type(), gate2.gate_type());
         return {pairs_of_commuting_1qubit_gates.find(pairGateType) != pairs_of_commuting_1qubit_gates.end(), gate1.gate_type() == gate2.gate_type()};
     }

--- a/src/qforte/make_gate.cc
+++ b/src/qforte/make_gate.cc
@@ -4,6 +4,17 @@
 
 #include "gate.h"
 
+double normalize_angle(double angle, double period) {
+    // Normalize the angle to be within [0, period)
+    angle = std::fmod(angle, period);
+    if (angle < -period / 2) {
+        angle += period;
+    } else if (angle > period / 2) {
+        angle -= period;
+    }
+    return angle;
+}
+
 Gate make_gate(std::string type, size_t target, size_t control, double parameter) {
     // using namespace std::complex_literals;
     std::complex<double> onei(0.0, 1.0);
@@ -38,6 +49,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate);
         }
         if (type == "R") {
+            parameter = normalize_angle(parameter, 2 * M_PI);
             std::complex<double> tmp = onei * parameter;
             std::complex<double> c = std::exp(tmp);
             std::complex<double> gate[4][4]{
@@ -47,6 +59,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate, std::make_pair(parameter, true));
         }
         if (type == "Rx") {
+            parameter = normalize_angle(parameter, 4 * M_PI);
             std::complex<double> a = std::cos(0.5 * parameter);
             std::complex<double> b = onei * std::sin(0.5 * parameter);
             std::complex<double> gate[4][4]{
@@ -56,6 +69,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate, std::make_pair(parameter, true));
         }
         if (type == "Ry") {
+            parameter = normalize_angle(parameter, 4 * M_PI);
             std::complex<double> a = std::cos(0.5 * parameter);
             std::complex<double> b = std::sin(0.5 * parameter);
             std::complex<double> gate[4][4]{
@@ -65,6 +79,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate, std::make_pair(parameter, true));
         }
         if (type == "Rz") {
+            parameter = normalize_angle(parameter, 4 * M_PI);
             std::complex<double> tmp_a = -onei * 0.5 * parameter;
             std::complex<double> a = std::exp(tmp_a);
             std::complex<double> tmp_b = onei * 0.5 * parameter;
@@ -109,6 +124,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
 
     } else {
         if (type == "A") {
+            parameter = normalize_angle(parameter, 2 * M_PI);
             std::complex<double> c = std::cos(parameter);
             std::complex<double> s = std::sin(parameter);
             std::complex<double> gate[4][4]{
@@ -156,6 +172,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate);
         }
         if (type == "cR") {
+            parameter = normalize_angle(parameter, 2 * M_PI);
             std::complex<double> tmp = onei * parameter;
             std::complex<double> c = std::exp(tmp);
             std::complex<double> gate[4][4]{
@@ -178,6 +195,7 @@ Gate make_gate(std::string type, size_t target, size_t control, double parameter
             return Gate(type, target, control, gate);
         }
         if (type == "cRz") {
+            parameter = normalize_angle(parameter, 4 * M_PI);
             std::complex<double> tmp_a = -onei * 0.5 * parameter;
             std::complex<double> a = std::exp(tmp_a);
             std::complex<double> tmp_b = onei * 0.5 * parameter;

--- a/tests/test_circuit_simplify.py
+++ b/tests/test_circuit_simplify.py
@@ -10,6 +10,8 @@ parametrized_gates = {'Rx','Ry','Rz', 'R', 'cR', 'cRz'}
 
 diagonal_1qubit_gates = {'T', 'S', 'Z', 'Rz', 'R'}
 
+phase_1qubit_gates = {'T', 'S', 'Z', 'R'}
+
 symmetrical_2qubit_gates = {'cZ', 'cR', 'SWAP'}
 
 involutory_gates = {'X', 'Y', 'Z', 'H',
@@ -101,6 +103,9 @@ class TestEvaluateGateInteraction:
                 gate2 = qf.gate(gatetype2, 0, 0, parameter)
             else:
                 gate2 = qf.gate(gatetype2, 0)
+            if gatetype1 in phase_1qubit_gates and gatetype2 in phase_1qubit_gates and gatetype2 != gatetype1:
+                assert (qf.evaluate_gate_interaction(gate1, gate2) == (True, 3))
+                continue
             assert (qf.evaluate_gate_interaction(gate1, gate2) == (True, simplifiable))
 
     def test_non_commuting_1qubit_gates(self):


### PR DESCRIPTION
## Description
The T, S, and Z gates are specific instances of the R phase gate. The simplification of pairs of these gates has been incorporated in the simplify function of the Circuit class.

To avoid numerical instabilities associated with large angles, the angle of parametrized gates has been restricted in the -period/2 to period/2 interval, where period = 2pi for the R, cR, and A gates and period = 4pi for the Rx, Ry, Rz, and cRz gates.

To facilitate the simplification of phase gates, the adjoints of T and S now return the corresponding R gate instead of adj(T) and adj(S).

## User Notes
- [X ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [x ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [ ] Ready to go!
