### PR TITLE
Fixed minor bug in Jacobi solver with DIIS

### DIFF
--- a/src/qforte/maths/optimizer.py
+++ b/src/qforte/maths/optimizer.py
@@ -64,6 +64,12 @@ def jacobi_solver(self):
 
         self._tamps = list(np.add(self._tamps, r_k))
 
+        t_diis.append(copy.deepcopy(self._tamps))
+        e_diis.append(np.subtract(copy.deepcopy(self._tamps), t_old))
+
+        if(k >= 1 and self._diis_max_dim >= 2):
+            self._tamps = diis(self._diis_max_dim, t_diis, e_diis)
+
         Ek = self.energy_feval(self._tamps)
         dE = Ek - Ek0
         Ek0 = Ek
@@ -78,12 +84,6 @@ def jacobi_solver(self):
             if(self._curr_grad_norm < self._opt_thresh):
                 self._Egs = Ek
                 break
-
-        t_diis.append(copy.deepcopy(self._tamps))
-        e_diis.append(np.subtract(copy.deepcopy(self._tamps), t_old))
-
-        if(k >= 1 and self._diis_max_dim >= 2):
-            self._tamps = diis(self._diis_max_dim, t_diis, e_diis)
 
     self._Egs = Ek
     if k == self._opt_maxiter:

--- a/tests/test_open_shells.py
+++ b/tests/test_open_shells.py
@@ -28,7 +28,7 @@ class TestOpenShellSystems:
         alg = UCCNPQE(mol, compact_excitations = True)
         alg.run(pool_type='SD')
 
-        assert alg._Egs == approx(-2.4998604383361855, abs=1.0e-12)
+        assert alg._Egs == approx(-2.4998604454039635, abs=1.0e-12)
 
     def test_H5_fci(self):
 


### PR DESCRIPTION
## Description
There was a minor bug in the Jacobi solver when DIIS was enabled. The reported energies were based on the amplitudes before the latest DIIS extrapolation. This created a mismatch between the energies reported by QForte and those computed as the expectation value of the Hamiltonian.

The bug was fixed by computing and reporting energies based on the extrapolated amplitudes.

The assertion value of only one test had to be slightly adjusted.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
