### PR TITLE
Implemented simplifications for adj(V) and adj(cV) gates

### DIFF
--- a/src/qforte/circuit.cc
+++ b/src/qforte/circuit.cc
@@ -255,10 +255,11 @@ void Circuit::simplify() {
                                                              GateType::R, GateType::cRz, GateType::cR};
 
     const std::unordered_set<GateType> square_root_gates = {GateType::T, GateType::S, GateType::V,
-                                                            GateType::cV};
+                                                            GateType::cV, GateType::adjV, GateType::adjcV};
 
     const std::unordered_map<GateType, std::string> simplify_square_root_gates = {{GateType::T, "S"}, {GateType::S, "Z"},
-                                                                                  {GateType::V, "X"}, {GateType::cV, "cX"}}; 
+                                                                                  {GateType::V, "X"}, {GateType::cV, "cX"},
+                                                                                  {GateType::adjV, "X"}, {GateType::adjcV, "cX"}}; 
 
     std::vector<size_t> gate_indices_to_remove;
 
@@ -315,6 +316,11 @@ void Circuit::simplify() {
                     gate_indices_to_remove.push_back(pos1);
                     gates_[pos2] =
                         make_gate("R", gates_[pos2].target(), gates_[pos2].control(), get_phase_gate_parameter(gate1) + get_phase_gate_parameter(gate2));
+                    break;
+                }
+                if (simplification_case == 4) {
+                    gate_indices_to_remove.push_back(pos1);
+                    gate_indices_to_remove.push_back(pos2);
                     break;
                 }
             } else {

--- a/src/qforte/gate.cc
+++ b/src/qforte/gate.cc
@@ -186,7 +186,8 @@ GateType Gate::mapLabelToType(const std::string& label_) {
         {"CNOT", GateType::cX}, {"cX", GateType::cX}, {"aCNOT", GateType::acX},
         {"acX", GateType::acX}, {"cY", GateType::cY}, {"cZ", GateType::cZ},
         {"cR", GateType::cR}, {"cV", GateType::cV}, {"cRz", GateType::cRz},
-        {"SWAP", GateType::SWAP}
+        {"SWAP", GateType::SWAP},
+        {"adj(V)", GateType::adjV}, {"adj(cV)", GateType::adjcV},
     };
 
     auto it = labelToType.find(label_);
@@ -214,14 +215,20 @@ struct pair_equal {
 
 const std::unordered_set<std::pair<GateType, GateType>, pair_hash, pair_equal> pairs_of_commuting_1qubit_gates = {
     {GateType::X, GateType::X}, {GateType::Rx, GateType::X}, {GateType::V, GateType::X},
+    {GateType::adjV, GateType::X},
     {GateType::Y, GateType::Y}, {GateType::Ry, GateType::Y}, {GateType::Z, GateType::Z},
     {GateType::S, GateType::Z}, {GateType::T, GateType::Z}, {GateType::Rz, GateType::Z},
     {GateType::R, GateType::Z}, {GateType::H, GateType::H}, {GateType::S, GateType::S},
     {GateType::S, GateType::T}, {GateType::Rz, GateType::S}, {GateType::R, GateType::S},
     {GateType::T, GateType::T}, {GateType::Rz, GateType::T}, {GateType::R, GateType::T},
-    {GateType::Rx, GateType::Rx}, {GateType::Rx, GateType::V}, {GateType::Ry, GateType::Ry},
+    {GateType::Rx, GateType::Rx}, {GateType::Rx, GateType::V}, {GateType::adjV, GateType::Rx},
+    {GateType::Ry, GateType::Ry},
     {GateType::Rz, GateType::Rz}, {GateType::R, GateType::Rz}, {GateType::R, GateType::R},
-    {GateType::V, GateType::V}
+    {GateType::V, GateType::V}, {GateType::adjV, GateType::V}, {GateType::adjV, GateType::adjV}
+};
+
+const std::unordered_set<std::pair<GateType, GateType>, pair_hash, pair_equal> V_adjV = {
+    {GateType::adjV, GateType::V}
 };
 
 const std::unordered_set<GateType> diagonal_1qubit_gates = {GateType::T, GateType::S, GateType::Z, GateType::Rz, GateType::R};
@@ -230,7 +237,7 @@ const std::unordered_set<GateType> phase_1qubit_gates = {GateType::T, GateType::
 
 const std::unordered_map<GateType, GateType> controlled_2qubit_to_1qubit_gate = {
     {GateType::cX, GateType::X}, {GateType::acX, GateType::X}, {GateType::cY, GateType::Y}, {GateType::cZ, GateType::Z},
-    {GateType::cRz, GateType::Rz}, {GateType::cR, GateType::R}, {GateType::cV, GateType::V}
+    {GateType::cRz, GateType::Rz}, {GateType::cR, GateType::R}, {GateType::cV, GateType::V}, {GateType::adjcV, GateType::adjV},
 };
 
 const std::unordered_set<GateType> symmetrical_2qubit_gates = {GateType::cZ, GateType::cR, GateType::SWAP};
@@ -265,7 +272,8 @@ std::pair<bool, int> evaluate_gate_interaction(const Gate& gate1, const Gate& ga
             }
         }
         std::pair<GateType, GateType> pairGateType = std::make_pair(gate1.gate_type(), gate2.gate_type());
-        return {pairs_of_commuting_1qubit_gates.find(pairGateType) != pairs_of_commuting_1qubit_gates.end(), gate1.gate_type() == gate2.gate_type()};
+        return {pairs_of_commuting_1qubit_gates.find(pairGateType) != pairs_of_commuting_1qubit_gates.end(),
+            (gate1.gate_type() == gate2.gate_type()) + 4 * (V_adjV.find(pairGateType) != V_adjV.end())};
     }
 
     if (product_nqubits == 2) {
@@ -314,7 +322,8 @@ std::pair<bool, int> evaluate_gate_interaction(const Gate& gate1, const Gate& ga
             }
             if (gate1.target() == gate2.target()) {
                 std::pair<GateType, GateType> pairGateType = std::make_pair(controlled_2qubit_to_1qubit_gate.at(gate1.gate_type()), controlled_2qubit_to_1qubit_gate.at(gate2.gate_type()));
-                return {pairs_of_commuting_1qubit_gates.find(pairGateType) != pairs_of_commuting_1qubit_gates.end(), gate1.gate_type() == gate2.gate_type()};
+                return {pairs_of_commuting_1qubit_gates.find(pairGateType) != pairs_of_commuting_1qubit_gates.end(),
+                    (gate1.gate_type() == gate2.gate_type()) + 4 * (V_adjV.find(pairGateType) != V_adjV.end())};
             }
             return {diagonal_1qubit_gates.find(controlled_2qubit_to_1qubit_gate.at(gate1.gate_type())) != diagonal_1qubit_gates.end() && diagonal_1qubit_gates.find(controlled_2qubit_to_1qubit_gate.at(gate2.gate_type())) != diagonal_1qubit_gates.end(), 0};
         }

--- a/src/qforte/gate.h
+++ b/src/qforte/gate.h
@@ -18,7 +18,7 @@ class SparseVector;
 
 /// useful for type safety and efficient comparisons
 enum class GateType {
-    X, Y, Z, H, R, Rx, Ry, Rz, V, S, T, I, A, cX, acX, cY, cZ, cR, cV, cRz, SWAP, Undefined
+    X, Y, Z, H, R, Rx, Ry, Rz, V, adjV, S, T, I, A, cX, acX, cY, cZ, cR, cV, adjcV, cRz, SWAP, Undefined
 };
 
 /// alias for a 4 x 4 complex matrix stored as an array of arrays

--- a/tests/test_circuit_simplify.py
+++ b/tests/test_circuit_simplify.py
@@ -3,8 +3,8 @@ import qforte as qf
 import numpy as np
 import random
 
-one_qubit_gate_pool = ['X','Y','Z','Rx','Ry','Rz','H','S','T','R','V']
-two_qubit_gate_pool = ['CNOT', 'aCNOT', 'cY', 'cZ', 'cV', 'SWAP', 'cRz', 'cR', 'A']
+one_qubit_gate_pool = ['X','Y','Z','Rx','Ry','Rz','H','S','T','R','V', 'adj(V)']
+two_qubit_gate_pool = ['CNOT', 'aCNOT', 'cY', 'cZ', 'cV', 'SWAP', 'cRz', 'cR', 'A', 'adj(cV)']
 
 parametrized_gates = {'Rx','Ry','Rz', 'R', 'cR', 'cRz', 'A'}
 
@@ -27,19 +27,24 @@ pairs_of_commuting_1qubit_gates = {('X',   'X'), ('Rx',  'X'), ('V',   'X'), ('Y
                                    ('S',   'T'), ('Rz',  'S'), ('R',   'S'), ('T',  'T'),
                                    ('Rz',  'T'), ('R',   'T'), ('Rx', 'Rx'), ('Rx', 'V'),
                                    ('Ry', 'Ry'), ('Rz', 'Rz'), ('R',  'Rz'), ('R',  'R'),
-                                   ('V',   'V')}
+                                   ('V',   'V'), ('adj(V)', 'X'), ('adj(V)', 'Rx'),
+                                   ('adj(V)', 'V'), ('adj(V)', 'adj(V)')}
 
 pairs_of_simplifiable_1qubit_gates = {('X',   'X'), ('Y',   'Y'), ('Z',   'Z'),
                                     ('H',   'H'), ('S',   'S'), ('T',   'T'),
                                     ('Rx', 'Rx'), ('Ry', 'Ry'), ('Rz', 'Rz'),
-                                    ('R',   'R'), ('V',   'V')}
+                                    ('R',   'R'), ('V',   'V'), ('S',   'T'),
+                                    ('T',   'Z'), ('R',   'T'), ('S',   'Z'),
+                                    ('R',   'S'), ('R',   'Z'), ('adj(V)', 'V'),
+                                    ('adj(V)', 'adj(V)')}
 
 controlled_2qubit_to_1qubit_gate = {'CNOT': 'X', 'cX': 'X', 'aCNOT': 'X', 'acX': 'X',
-                                    'cY': 'Y', 'cZ': 'Z', 'cRz': 'Rz', 'cR': 'R', 'cV': 'V'}
+                                    'cY': 'Y', 'cZ': 'Z', 'cRz': 'Rz', 'cR': 'R', 'cV': 'V',
+                                    'adj(cV)': 'adj(V)'}
 
-square_root_gates = {'T', 'S', 'V', 'cV'}
+square_root_gates = {'T', 'S', 'V', 'cV', 'adj(V)', 'adj(cV)'}
 
-simplify_square_root_gates = {'T' : 'S', 'S' : 'Z', 'V' : 'X', 'cV' : 'cX'}
+simplify_square_root_gates = {'T' : 'S', 'S' : 'Z', 'V' : 'X', 'cV' : 'cX', 'adj(V)' : 'X', 'adj(cV)' : 'cX'}
 
 class TestEvaluateGateInteraction:
 
@@ -51,6 +56,9 @@ class TestEvaluateGateInteraction:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 0, parameter)
+            elif (gatetype1 == 'adj(V)'):
+                gate1 = qf.gate('V', 0)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0)
             for j in range(i, len(one_qubit_gate_pool)):
@@ -59,6 +67,9 @@ class TestEvaluateGateInteraction:
                     period = parametrized_gate_periods[gatetype2]
                     parameter = random.uniform(-period, period)
                     gate2 = qf.gate(gatetype2, 1, 1, parameter)
+                elif gatetype2 == 'adj(V)':
+                    gate2 = qf.gate('V', 1)
+                    gate2 = gate2.adjoint()
                 else:
                     gate2 = qf.gate(gatetype2, 1)
                 assert(qf.evaluate_gate_interaction(gate1, gate2) == (True, 0))
@@ -69,6 +80,9 @@ class TestEvaluateGateInteraction:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 0, parameter)
+            elif (gatetype1 == 'adj(V)'):
+                gate1 = qf.gate('V', 0)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0)
             for gatetype2 in two_qubit_gate_pool:
@@ -76,6 +90,9 @@ class TestEvaluateGateInteraction:
                     period = parametrized_gate_periods[gatetype2]
                     parameter = random.uniform(-period, period)
                     gate2 = qf.gate(gatetype2, 1, 2, parameter)
+                elif gatetype2 == 'adj(cV)':
+                    gate2 = qf.gate('cV', 1, 2)
+                    gate2 = gate2.adjoint()
                 else:
                     gate2 = qf.gate(gatetype2, 1, 2)
                 assert(qf.evaluate_gate_interaction(gate1, gate2) == (True, 0))
@@ -87,6 +104,9 @@ class TestEvaluateGateInteraction:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 1, parameter)
+            elif gatetype1 == 'adj(cV)':
+                gate1 = qf.gate('cV', 0, 1)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0, 1)
             for j in range(i, len(two_qubit_gate_pool)):
@@ -95,30 +115,43 @@ class TestEvaluateGateInteraction:
                     period = parametrized_gate_periods[gatetype2]
                     parameter = random.uniform(-period, period)
                     gate2 = qf.gate(gatetype2, 2, 3, parameter)
+                elif gatetype2 == 'adj(cV)':
+                    gate2 = qf.gate('cV', 2, 3)
+                    gate2 = gate2.adjoint()
                 else:
                     gate2 = qf.gate(gatetype2, 2, 3)
                 assert(qf.evaluate_gate_interaction(gate1, gate2) == (True, 0))
 
     def test_commuting_1qubit_gates(self):
-        for i in pairs_of_commuting_1qubit_gates:
-            simplifiable = i in pairs_of_simplifiable_1qubit_gates
-            gatetype1, gatetype2 = i[0], i[1]
+        for gatetype1, gatetype2 in pairs_of_commuting_1qubit_gates:
+            if (gatetype1,gatetype2) in pairs_of_simplifiable_1qubit_gates:
+                if (gatetype1, gatetype2) == ('adj(V)', 'V'):
+                    simplification_case = 4
+                elif gatetype1 in phase_1qubit_gates and gatetype2 in phase_1qubit_gates and gatetype2 != gatetype1:
+                    simplification_case = 3
+                else:
+                    simplification_case = 1
+            else:
+                simplification_case = 0
             if gatetype1 in parametrized_gates:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 0, parameter)
+            elif gatetype1 == 'adj(V)':
+                gate1 = qf.gate('V', 0)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0)
             if gatetype2 in parametrized_gates:
                 period = parametrized_gate_periods[gatetype2]
                 parameter = random.uniform(-period, period)
                 gate2 = qf.gate(gatetype2, 0, 0, parameter)
+            elif gatetype2 == 'adj(V)':
+                gate2 = qf.gate('V', 0)
+                gate2 = gate2.adjoint()
             else:
                 gate2 = qf.gate(gatetype2, 0)
-            if gatetype1 in phase_1qubit_gates and gatetype2 in phase_1qubit_gates and gatetype2 != gatetype1:
-                assert (qf.evaluate_gate_interaction(gate1, gate2) == (True, 3))
-                continue
-            assert (qf.evaluate_gate_interaction(gate1, gate2) == (True, simplifiable))
+            assert (qf.evaluate_gate_interaction(gate1, gate2) == (True, simplification_case))
 
     def test_non_commuting_1qubit_gates(self):
         for i in range(len(one_qubit_gate_pool)):
@@ -127,16 +160,22 @@ class TestEvaluateGateInteraction:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 0, parameter)
+            elif gatetype1 == 'adj(V)':
+                gate1 = qf.gate('V', 0)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0)
             for j in range(i, len(one_qubit_gate_pool)):
                 gatetype2 = one_qubit_gate_pool[j]
-                if tuple(sorted((gatetype1, gatetype2))) in pairs_of_commuting_1qubit_gates:
+                if tuple(sorted((gatetype1, gatetype2), key=str.lower)) in pairs_of_commuting_1qubit_gates:
                     continue
                 if gatetype2 in parametrized_gates:
                     period = parametrized_gate_periods[gatetype2]
                     parameter = random.uniform(-period, period)
                     gate2 = qf.gate(gatetype2, 0, 0, parameter)
+                elif gatetype2 == 'adj(V)':
+                    gate2 = qf.gate('V', 0)
+                    gate2 = gate2.adjoint()
                 else:
                     gate2 = qf.gate(gatetype2, 0)
                 assert (qf.evaluate_gate_interaction(gate1, gate2) == (False, 0))
@@ -148,6 +187,11 @@ class TestEvaluateGateInteraction:
                 parameter = random.uniform(-period, period)
                 one_qubit_gate_target = qf.gate(one_qubit_gate_type, 0, 0, parameter)
                 one_qubit_gate_control = qf.gate(one_qubit_gate_type, 1, 1, parameter)
+            elif one_qubit_gate_type == 'adj(V)':
+                one_qubit_gate_target = qf.gate('V', 0)
+                one_qubit_gate_target = one_qubit_gate_target.adjoint()
+                one_qubit_gate_control = qf.gate('V', 1)
+                one_qubit_gate_control = one_qubit_gate_control.adjoint()
             else:
                 one_qubit_gate_target = qf.gate(one_qubit_gate_type, 0)
                 one_qubit_gate_control = qf.gate(one_qubit_gate_type, 1)
@@ -156,13 +200,17 @@ class TestEvaluateGateInteraction:
                     period = parametrized_gate_periods[two_qubit_gate_type]
                     parameter = random.uniform(-period, period)
                     two_qubit_gate = qf.gate(two_qubit_gate_type, 0, 1, parameter)
+                elif two_qubit_gate_type == 'adj(cV)':
+                    two_qubit_gate = qf.gate('cV', 0, 1)
+                    two_qubit_gate = two_qubit_gate.adjoint()
                 else:
                     two_qubit_gate = qf.gate(two_qubit_gate_type, 0, 1)
+                print(one_qubit_gate_type, two_qubit_gate_type)
                 if two_qubit_gate_type == 'SWAP' or two_qubit_gate_type == 'A':
                     assert(qf.evaluate_gate_interaction(one_qubit_gate_target, two_qubit_gate) == (False, 0))
                     assert(qf.evaluate_gate_interaction(one_qubit_gate_control, two_qubit_gate) == (False, 0))
                     continue
-                if tuple(sorted((one_qubit_gate_type, controlled_2qubit_to_1qubit_gate[two_qubit_gate_type]))) in pairs_of_commuting_1qubit_gates:
+                if tuple(sorted((one_qubit_gate_type, controlled_2qubit_to_1qubit_gate[two_qubit_gate_type]), key=str.lower)) in pairs_of_commuting_1qubit_gates:
                     assert(qf.evaluate_gate_interaction(one_qubit_gate_target, two_qubit_gate) == (True, 0))
                 else:
                     assert(qf.evaluate_gate_interaction(one_qubit_gate_target, two_qubit_gate) == (False, 0))
@@ -178,6 +226,9 @@ class TestEvaluateGateInteraction:
                 period = parametrized_gate_periods[gatetype1]
                 parameter = random.uniform(-period, period)
                 gate1 = qf.gate(gatetype1, 0, 1, parameter)
+            elif gatetype1 == 'adj(cV)':
+                gate1 = qf.gate('cV', 0, 1)
+                gate1 = gate1.adjoint()
             else:
                 gate1 = qf.gate(gatetype1, 0, 1)
             for j in range(i, len(two_qubit_gate_pool)):
@@ -191,6 +242,19 @@ class TestEvaluateGateInteraction:
                     gate2d = qf.gate(gatetype2, 1, 2, parameter)
                     gate2e = qf.gate(gatetype2, 0, 1, parameter)
                     gate2f = qf.gate(gatetype2, 1, 0, parameter)
+                elif gatetype2 == 'adj(cV)':
+                    gate2a = qf.gate('cV', 0, 2)
+                    gate2b = qf.gate('cV', 2, 1)
+                    gate2c = qf.gate('cV', 2, 0)
+                    gate2d = qf.gate('cV', 1, 2)
+                    gate2e = qf.gate('cV', 0, 1)
+                    gate2f = qf.gate('cV', 1, 0)
+                    gate2a = gate2a.adjoint()
+                    gate2b = gate2b.adjoint()
+                    gate2c = gate2c.adjoint()
+                    gate2d = gate2d.adjoint()
+                    gate2e = gate2e.adjoint()
+                    gate2f = gate2f.adjoint()
                 else:
                     gate2a = qf.gate(gatetype2, 0, 2)
                     gate2b = qf.gate(gatetype2, 2, 1)
@@ -225,7 +289,7 @@ class TestEvaluateGateInteraction:
                         assert (qf.evaluate_gate_interaction(gate1, gate2e) == (False, 0))
                         assert (qf.evaluate_gate_interaction(gate1, gate2f) == (False, 0))
                 else:
-                    if tuple(sorted([controlled_2qubit_to_1qubit_gate[gatetype1], controlled_2qubit_to_1qubit_gate[gatetype2]])) in pairs_of_commuting_1qubit_gates:
+                    if tuple(sorted([controlled_2qubit_to_1qubit_gate[gatetype1], controlled_2qubit_to_1qubit_gate[gatetype2]], key=str.lower)) in pairs_of_commuting_1qubit_gates:
                         assert (qf.evaluate_gate_interaction(gate1, gate2a) == (True, 0))
                     else:
                         assert (qf.evaluate_gate_interaction(gate1, gate2a) == (False, 0))
@@ -242,8 +306,11 @@ class TestEvaluateGateInteraction:
                         assert (qf.evaluate_gate_interaction(gate1, gate2e) == (True, 2  * (gatetype1 == gatetype2)))
                         assert (qf.evaluate_gate_interaction(gate1, gate2f) == (True, 2  * (gatetype1 == gatetype2)))
                         continue
-                    if tuple(sorted([controlled_2qubit_to_1qubit_gate[gatetype1], controlled_2qubit_to_1qubit_gate[gatetype2]])) in pairs_of_commuting_1qubit_gates:
-                        assert (qf.evaluate_gate_interaction(gate1, gate2e) == (True, (gatetype1 == gatetype2)))
+                    if tuple(sorted([controlled_2qubit_to_1qubit_gate[gatetype1], controlled_2qubit_to_1qubit_gate[gatetype2]], key=str.lower)) in pairs_of_commuting_1qubit_gates:
+                        if tuple(sorted([controlled_2qubit_to_1qubit_gate[gatetype1], controlled_2qubit_to_1qubit_gate[gatetype2]], key=str.lower)) == ('adj(V)', 'V'):
+                            assert (qf.evaluate_gate_interaction(gate1, gate2e) == (True, 4))
+                        else:
+                            assert (qf.evaluate_gate_interaction(gate1, gate2e) == (True, (gatetype1 == gatetype2)))
                     else:
                         assert (qf.evaluate_gate_interaction(gate1, gate2e) == (False, 0))
                     if controlled_2qubit_to_1qubit_gate[gatetype1] in diagonal_1qubit_gates and controlled_2qubit_to_1qubit_gate[gatetype2] in diagonal_1qubit_gates:
@@ -326,19 +393,23 @@ class TestCircuitSimplify:
 
         for gatetype in square_root_gates:
             if gatetype in one_qubit_gate_pool:
-                circ = qf.Circuit()
-                circ.add(qf.gate(gatetype, 0))
-                circ.add(qf.gate(gatetype, 0))
-                circ.simplify()
-                assert circ.size() == 1
-                assert circ.gates()[0].gate_id() == simplify_square_root_gates[gatetype]
+                if gatetype == 'adj(V)':
+                    gate = qf.gate('V', 0)
+                    gate = gate.adjoint()
+                else:
+                    gate = qf.gate(gatetype, 0)
             else:
-                circ = qf.Circuit()
-                circ.add(qf.gate(gatetype, 0, 1))
-                circ.add(qf.gate(gatetype, 0, 1))
-                circ.simplify()
-                assert circ.size() == 1
-                assert circ.gates()[0].gate_id() == simplify_square_root_gates[gatetype]
+                if gatetype == 'adj(cV)':
+                    gate = qf.gate('cV', 0, 1)
+                    gate = gate.adjoint()
+                else:
+                    gate = qf.gate(gatetype, 0, 1)
+            circ = qf.Circuit()
+            circ.add(gate)
+            circ.add(gate)
+            circ.simplify()
+            assert circ.size() == 1
+            assert circ.gates()[0].gate_id() == simplify_square_root_gates[gatetype]
 
     def test_simplify_1qubit_phase_gates(slef):
 
@@ -371,6 +442,35 @@ class TestCircuitSimplify:
                 assert circ2.size() == 1
                 assert circ2.gates()[0].gate_id() == 'R'
 
+    def test_simplify_unitary_pairs(self):
+
+        for gatetype in ['V', 'cV', 'adj(V)', 'adj(cV)']:
+            if gatetype in one_qubit_gate_pool:
+                if gatetype == 'adj(V)':
+                    gate = qf.gate('V', 0)
+                    gate = gate.adjoint()
+                elif gatetype in parametrized_gates:
+                    period = parametrized_gate_periods[gatetype]
+                    parameter = random.uniform(-period/2, period/2)
+                    gate = qf.gate(gatetype, 0, 0, parameter)
+                else:
+                    gate = qf.gate(gatetype, 0)
+            else:
+                if gatetype == 'adj(cV)':
+                    gate = qf.gate('cV', 0, 1)
+                    gate = gate.adjoint()
+                elif gatetype in parametrized_gates:
+                    period = parametrized_gate_periods[gatetype]
+                    parameter = random.uniform(-period/2, period/2)
+                    gate = qf.gate(gatetype, 0, 1, parameter)
+                else:
+                    gate = qf.gate(gatetype, 0, 1)
+            gate_adjoint = gate.adjoint()
+            circ = qf.Circuit()
+            circ.add(gate)
+            circ.add(gate_adjoint)
+            circ.simplify()
+            assert circ.size() == 0
 
     def test_simplify_H6_STO6G_UCCSDT_ansatz_circuit(self):
 


### PR DESCRIPTION
## Description
These should be the last additions to the circuit simplification code. Now all existing QForte gates are accounted for.

V \times adj(V) return the identity and similar is true for the cV and adj(cV) gates.

The pertaining tests have been updated and all tests pass successfully.

## User Notes
- [x ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
