### PR TITLE
Made GitHub workflows more robust

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -16,21 +16,28 @@ jobs:
     - name: Install lcov
       run: sudo apt-get update && sudo apt-get install -y lcov
 
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Set up Miniconda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true  # Ensure conda is updated to the latest version
+        miniforge-variant: "Mambaforge"
 
-    - name: Install dependencies
+    - name: Create conda environment
       run: |
-        conda env update --file environment.yml --name base
+        source /usr/share/miniconda3/etc/profile.d/conda.sh
+        conda env create --file environment.yml --name qforte_env
+        echo "CONDA_ENV_NAME=qforte_env" >> $GITHUB_ENV
 
     - name: Compile
       run: |
+        source /usr/share/miniconda3/etc/profile.d/conda.sh
+        conda activate $CONDA_ENV_NAME
         QFORTE_CODECOV=ON python setup.py develop
         
     - name: Test with pytest
       run: |
+        source /usr/share/miniconda3/etc/profile.d/conda.sh
+        conda activate $CONDA_ENV_NAME
         lcov --directory . --zerocounters
         cd tests
         pytest


### PR DESCRIPTION
## Description
Some changes in GitHub caused the breaking of the workflows in QForte. This PR makes our GitHub actions more robust.

Instead of using the native conda of GitHub, the latest version of miniconda is downloaded and installed. The Mambaforge variant was selected since the Miniforge URL in GitHub was broken. Instead of updating the base environment with the QForte dependencies, a new qforte_env environment is created and activated as needed.

All tests in GitHub workflows successfully passed.

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x ] Ready to go!
