### PR TITLE
`get_pauli_permuted_idx` now returns `size_t`

### DIFF
--- a/src/qforte/computer.cc
+++ b/src/qforte/computer.cc
@@ -874,7 +874,7 @@ std::complex<double> Computer::direct_pauli_circ_exp_val(const Circuit& qc) {
     std::vector<int> y_idxs;
     std::vector<int> z_idxs;
 
-    for (const Gate& gate : qc.gates()) {
+    for (const auto& gate : qc.gates()) {
         if (gate.target() < min_qb_idx) {
             min_qb_idx = gate.target();
         }
@@ -894,16 +894,14 @@ std::complex<double> Computer::direct_pauli_circ_exp_val(const Circuit& qc) {
 
 #pragma omp parallel for reduction(+ : result)
     for (size_t n = 0; n < n_blocks; n++) {
-        int I1 = n * block_size;
-        int I2 = I1 + block_size;
+        size_t I1 = n * block_size;
+        size_t I2 = I1 + block_size;
 
-        std::pair<int, std::complex<double>> pauli_perms =
-            get_pauli_permuted_idx(I1, x_idxs, y_idxs, z_idxs);
+        auto pauli_perms = get_pauli_permuted_idx(I1, x_idxs, y_idxs, z_idxs);
 
-        std::vector<std::complex<double>>::iterator it1 = std::next(coeff_.begin(), I1);
-        std::vector<std::complex<double>>::iterator it2 = std::next(coeff_.begin(), I2);
-        std::vector<std::complex<double>>::iterator it3 =
-            std::next(coeff_.begin(), pauli_perms.first);
+        auto it1 = std::next(coeff_.begin(), I1);
+        auto it2 = std::next(coeff_.begin(), I2);
+        auto it3 = std::next(coeff_.begin(), pauli_perms.first);
 
         result +=
             pauli_perms.second * std::inner_product(it1, it2, it3, std::complex<double>(0.0, 0.0),
@@ -912,7 +910,7 @@ std::complex<double> Computer::direct_pauli_circ_exp_val(const Circuit& qc) {
     return result;
 }
 
-std::pair<int, std::complex<double>>
+std::pair<size_t, std::complex<double>>
 Computer::get_pauli_permuted_idx(size_t I, const std::vector<int>& x_idxs,
                                  const std::vector<int>& y_idxs, const std::vector<int>& z_idxs) {
 

--- a/src/qforte/computer.cc
+++ b/src/qforte/computer.cc
@@ -717,7 +717,7 @@ void Computer::apply_2qubit_gate(const Gate& qg) {
             }
             ntwo_ops_++;
         } // end if c < t
-    }     // end if controlled unitary
+    } // end if controlled unitary
     else {
         // Case 2: 2qubit gate is a not a control gate, use standard algorithm
         const auto& two_qubits_basis = Gate::two_qubits_basis();

--- a/src/qforte/computer.cc
+++ b/src/qforte/computer.cc
@@ -717,7 +717,7 @@ void Computer::apply_2qubit_gate(const Gate& qg) {
             }
             ntwo_ops_++;
         } // end if c < t
-    } // end if controlled unitary
+    }     // end if controlled unitary
     else {
         // Case 2: 2qubit gate is a not a control gate, use standard algorithm
         const auto& two_qubits_basis = Gate::two_qubits_basis();

--- a/src/qforte/computer.h
+++ b/src/qforte/computer.h
@@ -97,9 +97,9 @@ class Computer {
 
     /// get the idx I with respect to pauli circuit permutations from qc
     std::pair<size_t, std::complex<double>> get_pauli_permuted_idx(size_t I,
-                                                                const std::vector<int>& x_idxs,
-                                                                const std::vector<int>& y_idxs,
-                                                                const std::vector<int>& z_idxs);
+                                                                   const std::vector<int>& x_idxs,
+                                                                   const std::vector<int>& y_idxs,
+                                                                   const std::vector<int>& z_idxs);
 
     /// get the expectation value of a single 1qubit gate directly
     /// (without simulated measurement)

--- a/src/qforte/computer.h
+++ b/src/qforte/computer.h
@@ -96,7 +96,7 @@ class Computer {
     std::complex<double> direct_pauli_circ_exp_val(const Circuit& qc);
 
     /// get the idx I with respect to pauli circuit permutations from qc
-    std::pair<int, std::complex<double>> get_pauli_permuted_idx(size_t I,
+    std::pair<size_t, std::complex<double>> get_pauli_permuted_idx(size_t I,
                                                                 const std::vector<int>& x_idxs,
                                                                 const std::vector<int>& y_idxs,
                                                                 const std::vector<int>& z_idxs);

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -202,6 +202,7 @@ class UCCNPQE(UCCPQE):
         )
 
     def fill_excited_dets(self):
+        """ Populate self._excited_dets. """
         for _, sq_op in self._pool_obj:
             # 1. Identify the excitation operator
             # occ => i,j,k,...

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -202,7 +202,7 @@ class UCCNPQE(UCCPQE):
         )
 
     def fill_excited_dets(self):
-        """ Populate self._excited_dets. """
+        """Populate self._excited_dets."""
         for _, sq_op in self._pool_obj:
             # 1. Identify the excitation operator
             # occ => i,j,k,...


### PR DESCRIPTION
## Description
The `get_pauli_permuted_idx` utility function now returns a `size_t` rather than an `int` as its first argument. The method's only use is as an argument to `std::next`, which logically should be expecting a `size_t`.

Comments, `auto`, and changing other things to `size_t` to match also included.

## Checklist
- [x] Ready to go!
