### PR TITLE
Rename `QubitBasis::add` to `::index`

### DIFF
--- a/src/qforte/bindings.cc
+++ b/src/qforte/bindings.cc
@@ -143,7 +143,7 @@ PYBIND11_MODULE(qforte, m) {
         .def("__repr__", &QubitBasis::default_str)
         .def("flip_bit", &QubitBasis::flip_bit)
         .def("set_bit", &QubitBasis::set_bit)
-        .def("add", &QubitBasis::add)
+        .def("index", &QubitBasis::index)
         .def("get_bit", &QubitBasis::get_bit);
 
     py::class_<Computer, std::shared_ptr<Computer>>(m, "Computer")

--- a/src/qforte/computer.cc
+++ b/src/qforte/computer.cc
@@ -37,12 +37,12 @@ Computer::Computer(int nqubit, double print_threshold)
     coeff_[0] = 1.;
 }
 
-std::complex<double> Computer::coeff(const QubitBasis& basis) { return coeff_[basis.add()]; }
+std::complex<double> Computer::coeff(const QubitBasis& basis) { return coeff_[basis.index()]; }
 
 void Computer::set_state(std::vector<std::pair<QubitBasis, double_c>> state) {
     std::fill(coeff_.begin(), coeff_.end(), 0.0);
     for (const auto& basis_c : state) {
-        coeff_[basis_c.first.add()] = basis_c.second;
+        coeff_[basis_c.first.index()] = basis_c.second;
     }
 }
 
@@ -328,7 +328,7 @@ void Computer::apply_1qubit_gate_safe(const Gate& qg) {
                     if (basis_J.get_bit(target) == j) {
                         QubitBasis basis_I = basis_J;
                         basis_I.set_bit(target, i);
-                        new_coeff_[basis_I.add()] += op_i_j * coeff_[basis_J.add()];
+                        new_coeff_[basis_I.index()] += op_i_j * coeff_[basis_J.index()];
                     }
                 }
             }
@@ -445,7 +445,7 @@ void Computer::apply_2qubit_gate_safe(const Gate& qg) {
                         QubitBasis basis_I = basis_J;
                         basis_I.set_bit(control, i_c);
                         basis_I.set_bit(target, i_t);
-                        new_coeff_[basis_I.add()] += op_i_j * coeff_[basis_J.add()];
+                        new_coeff_[basis_I.index()] += op_i_j * coeff_[basis_J.index()];
                     }
                 }
             }
@@ -738,7 +738,7 @@ void Computer::apply_2qubit_gate(const Gate& qg) {
                             QubitBasis basis_I = basis_J;
                             basis_I.set_bit(control, i_c);
                             basis_I.set_bit(target, i_t);
-                            new_coeff_[basis_I.add()] += op_i_j * coeff_[basis_J.add()];
+                            new_coeff_[basis_I.index()] += op_i_j * coeff_[basis_J.index()];
                         }
                     }
                 }
@@ -931,7 +931,7 @@ Computer::get_pauli_permuted_idx(size_t I, const std::vector<int>& x_idxs,
         val *= (1.0 - 2.0 * basis_I.get_bit(zi));
     }
 
-    return std::make_pair(basis_I.add(), val);
+    return std::make_pair(basis_I.index(), val);
 }
 
 std::complex<double> Computer::direct_gate_exp_val(const Gate& qg) {

--- a/src/qforte/gate.cc
+++ b/src/qforte/gate.cc
@@ -45,7 +45,7 @@ const SparseMatrix Gate::sparse_matrix(size_t nqubit) const {
                     if (basis_I.get_bit(target_) == j) {
                         QubitBasis basis_J = basis_I;
                         basis_J.set_bit(target_, i);
-                        Spmat.set_element(basis_J.add(), basis_I.add(), op_i_j);
+                        Spmat.set_element(basis_J.index(), basis_I.index(), op_i_j);
                     }
                 }
             }

--- a/src/qforte/qubit_basis.h
+++ b/src/qforte/qubit_basis.h
@@ -40,8 +40,8 @@ class QubitBasis {
     /// set this state to zero
     void zero() { state_ = static_cast<basis_t>(0); }
 
-    /// return the address of the state
-    size_t add() const { return state_; }
+    /// Convenience function to return state_ as an index.
+    size_t index() const { return static_cast<size_t>(state_); }
 
     /// return the state
     basis_t get_state() const { return state_; }

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -251,7 +251,7 @@ class UCCNPQE(UCCPQE):
                     "no ops should destroy reference, something went wrong!!"
                 )
 
-            I = excited_det.add()
+            I = excited_det.index()
 
             qc_temp = qforte.Computer(self._nqb)
             qc_temp.apply_circuit(self._Uprep)


### PR DESCRIPTION
## Description
Renames a very misleadingly named function.

## User Notes
- [x] `QubitBasis.add()` is now accessed as `QubitBasis.index()`

## Checklist
- [x] Ready to go!
