### PR TITLE
Add default args to experimental average

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -302,7 +302,7 @@ class AnsatzAlgorithm(Algorithm):
             val = np.real(myQC.direct_op_exp_val(self._qb_ham))
         else:
             Exp = qforte.Experiment(self._nqb, Ucirc, self._qb_ham, 2000)
-            val = Exp.perfect_experimental_avg([])
+            val = Exp.perfect_experimental_avg()
 
         assert np.isclose(np.imag(val), 0.0)
 

--- a/src/qforte/abc/qsdabc.py
+++ b/src/qforte/abc/qsdabc.py
@@ -24,7 +24,7 @@ class QSD(Algorithm):
     such as the Hartree-Fock state.
 
     Quantum subspace diagonalization methods work by constructing an effective
-    Hamiltonain :math:`\mathbf{H}` with matrix elements given by
+    Hamiltonian :math:`\mathbf{H}` with matrix elements given by
 
     .. math::
         H_{mn} = \\langle \Psi_m | \hat{H} | \Psi_n \\rangle,

--- a/src/qforte/experiment/experiment.py
+++ b/src/qforte/experiment/experiment.py
@@ -12,7 +12,7 @@ class Experiment(object):
         self, n_qubits, generator, operator, N_samples, prepare_each_time=False
     ):
         """
-        Experimant is a class that exemplifies two quantum computational tasks:
+        Experiment is a class that exemplifies two quantum computational tasks:
         (1) state preparation from a 'generator' circuit which may or may not be
         parameterized, and (2) to measure operators to produce approximate
         expectation values.
@@ -38,7 +38,7 @@ class Experiment(object):
         self.N_samples_ = N_samples
         self.prepare_each_time_ = prepare_each_time
 
-    def experimental_avg(self, params):
+    def experimental_avg(self, params = []):
         """
         calculates the experimental average of the operator the Experiment object was initialized with
 
@@ -75,7 +75,7 @@ class Experiment(object):
                 "No support yet for measurement with multiple state preparations"
             )
 
-    def perfect_experimental_avg(self, params):
+    def perfect_experimental_avg(self, params = []):
         """
         calculates the exact experimental result of the operator the Experiment object was initialized with
 

--- a/src/qforte/experiment/experiment.py
+++ b/src/qforte/experiment/experiment.py
@@ -38,7 +38,7 @@ class Experiment(object):
         self.N_samples_ = N_samples
         self.prepare_each_time_ = prepare_each_time
 
-    def experimental_avg(self, params = []):
+    def experimental_avg(self, params=[]):
         """
         calculates the experimental average of the operator the Experiment object was initialized with
 
@@ -75,7 +75,7 @@ class Experiment(object):
                 "No support yet for measurement with multiple state preparations"
             )
 
-    def perfect_experimental_avg(self, params = []):
+    def perfect_experimental_avg(self, params=[]):
         """
         calculates the exact experimental result of the operator the Experiment object was initialized with
 

--- a/src/qforte/qkd/srqk.py
+++ b/src/qforte/qkd/srqk.py
@@ -127,22 +127,13 @@ class SRQK(Trotterizable, QSD):
 
         if self._diagonalize_each_step:
             print("\n\n")
-
-            print(
-                f"{'k(S)':>7}{'E(Npar)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}"
-            )
-            print(
-                "-------------------------------------------------------------------------------"
-            )
+            string = f"{'k(S)':>7}{'E(Npar)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}\n"
+            string += "-------------------------------------------------------------------------------"
+            print(string)
 
             if self._print_summary_file:
                 f = open("summary.dat", "w+", buffering=1)
-                f.write(
-                    f"#{'k(S)':>7}{'E(Npar)':>19}{'N(params)':>14}{'N(CNOT)':>18}{'N(measure)':>20}\n"
-                )
-                f.write(
-                    "#-------------------------------------------------------------------------------\n"
-                )
+                f.write(string + "\n")
 
         for m in range(self._nstates):
             # Compute U_m = exp(-i m dt H)
@@ -226,7 +217,7 @@ class SRQK(Trotterizable, QSD):
 
         return s_mat, h_mat
 
-    # TODO depricate this function
+    # TODO deprecate this function
     def matrix_element(self, m, n, use_op=False):
         """Returns a single matrix element M_mn based on the evolution of
         two unitary operators Um = exp(-i * m * dt * H) and Un = exp(-i * n * dt * H)
@@ -314,9 +305,8 @@ class SRQK(Trotterizable, QSD):
             X_exp = qforte.Experiment(self._nqb + 1, cir, X_op, 100)
             Y_exp = qforte.Experiment(self._nqb + 1, cir, Y_op, 100)
 
-            params = [1.0]
-            x_value = X_exp.perfect_experimental_avg(params)
-            y_value = Y_exp.perfect_experimental_avg(params)
+            x_value = X_exp.perfect_experimental_avg()
+            y_value = Y_exp.perfect_experimental_avg()
 
             value = (x_value + 1.0j * y_value) * phase1 * np.conj(phase2)
 
@@ -362,10 +352,8 @@ class SRQK(Trotterizable, QSD):
                 X_exp = qforte.Experiment(self._nqb + 1, cir, X_op, 100)
                 Y_exp = qforte.Experiment(self._nqb + 1, cir, Y_op, 100)
 
-                # TODO (cleanup): Remove params as required arg (Nick)
-                params = [1.0]
-                x_value = X_exp.perfect_experimental_avg(params)
-                y_value = Y_exp.perfect_experimental_avg(params)
+                x_value = X_exp.perfect_experimental_avg()
+                y_value = Y_exp.perfect_experimental_avg()
 
                 element = (x_value + 1.0j * y_value) * phase1 * np.conj(phase2)
                 value += c * element

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -55,8 +55,7 @@ class TestExperiment:
         circ.add(gate("X", 1, 1))
 
         TestExperiment = Experiment(4, circ, H2_qubit_hamiltonian, 1000000)
-        params2 = []
-        avg_energy = TestExperiment.experimental_avg(params2)
+        avg_energy = TestExperiment.experimental_avg()
         print("Measured H2 Experimental Avg. Energy")
         print(avg_energy)
         print("H2 RHF Energy")
@@ -118,8 +117,7 @@ class TestExperiment:
         circ.add(gate("X", 1, 1))
 
         TestExperiment = Experiment(4, circ, H2_qubit_hamiltonian, 1000000)
-        params2 = []
-        avg_energy = TestExperiment.perfect_experimental_avg(params2)
+        avg_energy = TestExperiment.perfect_experimental_avg()
         print("Perfectly Measured H2 Experimental Avg. Energy")
         print(avg_energy)
         print("H2 RHF Energy")


### PR DESCRIPTION
## Description
This resolves an old TODO list item by giving `Experiment` methods the ability to take `params` as an optional parameter.

This is a simple one, so only one review is probably necessary. I'm just pinging both of you to expedite this one. 🙂 

## User Notes
- [x] `Experiment.experimental_avg()` and `Experiment.perfect_experimental_avg()` now take a default argument.

## Checklist
- [x] Ready to go!
