### PR TITLE
SRQK uses Circuit copy

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -73,7 +73,7 @@ class Algorithm(ABC):
         self._state_prep_type = state_prep_type
 
         if self._state_prep_type == "occupation_list":
-            if reference == None:
+            if reference is None:
                 self._ref = system.hf_reference
             else:
                 if not (isinstance(reference, list)):

--- a/src/qforte/qkd/srqk.py
+++ b/src/qforte/qkd/srqk.py
@@ -137,8 +137,7 @@ class SRQK(Trotterizable, QSD):
 
         for m in range(self._nstates):
             # Compute U_m = exp(-i m dt H)
-            Um = qforte.Circuit()
-            Um.add(self._Uprep)
+            Um = qforte.Circuit(self._Uprep)
             phase1 = 1.0
 
             if m > 0:
@@ -234,6 +233,9 @@ class SRQK(Trotterizable, QSD):
         n : int
             The number of time steps for the Un evolution.
 
+        use_op : bool
+            Should the matrix element be of H (true) or S (false)?
+
         Returns
         -------
         value : complex
@@ -277,11 +279,7 @@ class SRQK(Trotterizable, QSD):
             Ub.add(gate)
 
         if not use_op:
-            # TODO (opt): use Uprep
-            cir = qforte.Circuit()
-            for j in range(self._nqb):
-                if self._ref[j] == 1:
-                    cir.add(qforte.gate("X", j, j))
+            cir = qforte.Circuit(self._Uprep)
 
             cir.add(qforte.gate("H", ancilla_idx, ancilla_idx))
 
@@ -323,11 +321,7 @@ class SRQK(Trotterizable, QSD):
                     control_gate_str = "c" + gate_str
                     cV_l.add(qforte.gate(control_gate_str, target, ancilla_idx))
 
-                cir = qforte.Circuit()
-                # TODO (opt): use Uprep
-                for j in range(self._nqb):
-                    if self._ref[j] == 1:
-                        cir.add(qforte.gate("X", j, j))
+                cir = qforte.Circuit(self._Uprep)
 
                 cir.add(qforte.gate("H", ancilla_idx, ancilla_idx))
 

--- a/tests/test_slow_qk.py
+++ b/tests/test_slow_qk.py
@@ -1,5 +1,5 @@
 from pytest import approx
-from qforte import Circuit, build_circuit, QubitOperator, Molecule, MRSQK, SRQK
+from qforte import Circuit, build_circuit, QubitOperator, Molecule, MRSQK, SRQK, gate
 
 
 class TestPhysicalQKD:
@@ -394,6 +394,7 @@ class TestPhysicalQKD:
         # make test with algorithm class
         mol = Molecule()
         mol.hamiltonian = H4_qubit_hamiltonian
+        mol.hf_reference = ref.copy()
 
         # SRQK
         alg1 = SRQK(mol, reference=ref, trotter_number=1, fast=False)
@@ -402,3 +403,24 @@ class TestPhysicalQKD:
 
         Egs1_fast = -1.9982299799
         assert Egs1 == approx(Egs1_fast, abs=1.0e-9)
+
+        ref = Circuit()
+        ref.add_gate(gate("X", 0, 0))
+        ref.add_gate(gate("X", 1, 1))
+        ref.add_gate(gate("X", 2, 2))
+        ref.add_gate(gate("X", 3, 3))
+        ref.add_gate(gate("Ry", 0, 0, 0.1))
+        ref.add_gate(gate("Ry", 1, 1, 0.1))
+
+        alg2 = SRQK(
+            mol,
+            reference=ref,
+            trotter_number=1,
+            fast=False,
+            state_prep_type="unitary_circ",
+        )
+        alg2.run(s=3)
+        Egs2 = alg2.get_gs_energy()
+
+        Egs2_fast = -1.9977703813619807
+        assert Egs2 == approx(Egs2_fast, abs=1.0e-9)


### PR DESCRIPTION
## Description
This PR is both simple cleanup and a fix to a subtle bug. If the user passes in `_Uprep`, the old code would ignore that in the slow version but not in the fast version of SRQK. So rather than let the user start from a circuit, they _must_ start from HF, before this PR.

## User Notes
- [x] Fixed a bug where SRQK gives different results in fast/slow mode, if the user passes in `_Uprep`.

## Checklist
- [x] Do you have any idea how to test this one?
- [x] Ready to go!
