### PR TITLE
`QubitOpPool::fill_pool` now takes size_t

### DIFF
--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -220,10 +220,10 @@ class QITE(Trotterizable, Algorithm):
                 raise ValueError(
                     "Using complete qubits expansion will result in a very large number of terms!"
                 )
-            self._sig.fill_pool("complete_qubit", self._ref)
+            self._sig.fill_pool("complete_qubit", self._nqb)
 
         elif self._expansion_type == "cqoy":
-            self._sig.fill_pool("cqoy", self._ref)
+            self._sig.fill_pool("cqoy", self._nqb)
 
         elif self._expansion_type in {"SD", "GSD", "SDT", "SDTQ", "SDTQP", "SDTQPH"}:
             P = qf.SQOpPool()

--- a/src/qforte/qubit_op_pool.cc
+++ b/src/qforte/qubit_op_pool.cc
@@ -121,21 +121,21 @@ void QubitOpPool::join_as_commutator(const QubitOperator& q_op) {
     terms_ = std::move(temp_terms);
 }
 
-void QubitOpPool::fill_pool(std::string pool_type, const std::vector<int>& ref) {
+void QubitOpPool::fill_pool(std::string pool_type, const size_t nqb) {
     if (pool_type == "complete_qubit") {
         std::map<std::string, std::string> paulis = {
             {"0", "I"}, {"1", "X"}, {"2", "Y"}, {"3", "Z"}};
-        int nterms = static_cast<int>(std::pow(4, ref.size()));
+        int nterms = static_cast<int>(std::pow(4, nqb));
 
         for (int I = 0; I < nterms; I++) {
             QubitOperator AI;
             Circuit aI;
-            std::string paulistr = pauli_idx_str(to_base4(I), ref.size());
-            if (paulistr.length() != ref.size()) {
-                throw std::invalid_argument("paulistr.length() != ref.size()");
+            auto paulistr = pauli_idx_str(to_base4(I), nqb);
+            if (paulistr.length() != nqb) {
+                throw std::invalid_argument("paulistr.length() != nqb");
             }
 
-            for (int k = 0; k < ref.size(); k++) {
+            for (size_t k = 0; k < nqb; k++) {
                 if (paulistr.substr(k, 1) != "0") {
                     aI.add_gate(make_gate(paulis[paulistr.substr(k, 1)], k, k));
                 }
@@ -146,17 +146,17 @@ void QubitOpPool::fill_pool(std::string pool_type, const std::vector<int>& ref) 
     } else if (pool_type == "cqoy") {
         std::map<std::string, std::string> paulis = {
             {"0", "I"}, {"1", "X"}, {"2", "Y"}, {"3", "Z"}};
-        int nterms = static_cast<int>(std::pow(4, ref.size()));
+        int nterms = static_cast<int>(std::pow(4, nqb));
 
         for (int I = 0; I < nterms; I++) {
             QubitOperator AI;
             Circuit aI;
-            std::string paulistr = pauli_idx_str(to_base4(I), ref.size());
-            if (paulistr.length() != ref.size()) {
-                throw std::invalid_argument("paulistr.length() != ref.size()");
+            auto paulistr = pauli_idx_str(to_base4(I), nqb);
+            if (paulistr.length() != nqb) {
+                throw std::invalid_argument("paulistr.length() != nqb");
             }
             int nygates = 0;
-            for (int k = 0; k < ref.size(); k++) {
+            for (size_t k = 0; k < nqb; k++) {
                 if (paulistr.substr(k, 1) == "2") {
                     nygates++;
                 }

--- a/src/qforte/qubit_op_pool.h
+++ b/src/qforte/qubit_op_pool.h
@@ -52,7 +52,7 @@ class QubitOpPool {
     void square(bool upper_triangle_only);
 
     /// builds the quantum operator pool, will be used in qite
-    void fill_pool(std::string pool_type, const std::vector<int>& ref);
+    void fill_pool(std::string pool_type, const size_t nqb);
 
     /// return a vector of strings representing this quantum operator pool
     std::string str() const;


### PR DESCRIPTION
## Description
`QubitOpPool::fill_pool` is a qubit basis method, so it shouldn't need to know about any electronic structure, such as references. It just needs to know how many qubits we have.

## User Notes
- [x] `QubitOpPool::fill_pool` now takes the number of qubits, rather than an occupation string.

## Checklist
- [x] Ready to go!
