### PR TITLE
Fixed bug that allowed sa_SD ansätze to break particle number and Sz symmetries

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -265,10 +265,6 @@ class AnsatzAlgorithm(Algorithm):
         """This function populates an operator pool with SQOperator objects."""
 
         if self._pool_type in {"sa_SD", "GSD", "SD", "SDT", "SDTQ", "SDTQP", "SDTQPH"}:
-            if self._pool_type == "sa_SD" and self._compact_excitations:
-                raise ValueError(
-                    "Compact excitation circuits not yet implemented for sa_SD operator pool."
-                )
             self._pool_obj = qf.SQOpPool()
             if hasattr(self._sys, "orb_irreps_to_int"):
                 self._pool_obj.set_orb_spaces(self._ref, self._sys.orb_irreps_to_int)

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -183,28 +183,60 @@ class UCCVQE(VQE, UCC):
             Kmu.mult_coeffs(self._pool_obj[self._tops[mu]][0])
 
             if self._compact_excitations:
-                Umu = qf.Circuit()
-                # The minus sign is dictated by the recursive algorithm used to compute the analytic gradient
-                # (see original ADAPT-VQE paper)
-                Umu.add(
-                    compact_excitation_circuit(
-                        -tamp * self._pool_obj[self._tops[mu + 1]][1].terms()[1][0],
-                        self._pool_obj[self._tops[mu + 1]][1].terms()[1][1],
-                        self._pool_obj[self._tops[mu + 1]][1].terms()[1][2],
-                        self._qubit_excitations,
+                if self._pool_type == "sa_SD":
+                    sa_sq_op = self._pool_obj[self._tops[mu + 1]][1].terms()
+                    half_length = len(sa_sq_op) // 2
+                    Umu = qf.Circuit()
+                    for coeff, cr, ann in sa_sq_op[:half_length]:
+                        # The minus sign is dictated by the recursive algorithm used to compute the analytic gradient
+                        # (see original ADAPT-VQE paper)
+                        # In this particular case, the minus sign is already incorporated
+                        Umu.add(
+                            compact_excitation_circuit(
+                                tamp * coeff, ann, cr, self._qubit_excitations
+                            )
+                        )
+                else:
+                    Umu = qf.Circuit()
+                    # The minus sign is dictated by the recursive algorithm used to compute the analytic gradient
+                    # (see original ADAPT-VQE paper)
+                    Umu.add(
+                        compact_excitation_circuit(
+                            -tamp * self._pool_obj[self._tops[mu + 1]][1].terms()[1][0],
+                            self._pool_obj[self._tops[mu + 1]][1].terms()[1][1],
+                            self._pool_obj[self._tops[mu + 1]][1].terms()[1][2],
+                            self._qubit_excitations,
+                        )
                     )
-                )
             else:
-                # The minus sign is dictated by the recursive algorithm used to compute the analytic gradient
-                # (see original ADAPT-VQE paper)
-                Umu, pmu = trotterize(
-                    Kmu_prev, factor=-tamp, trotter_number=self._trotter_number
-                )
-
-                if pmu != 1.0 + 0.0j:
-                    raise ValueError(
-                        "Encountered phase change, phase not equal to (1.0 + 0.0i)"
+                if self._pool_type == "sa_SD":
+                    sa_sq_op = self._pool_obj[self._tops[mu + 1]][1].terms()
+                    half_length = len(sa_sq_op) // 2
+                    Umu = qf.Circuit()
+                    for coeff, cr, ann in sa_sq_op[:half_length]:
+                        sq_op = qf.SQOperator()
+                        sq_op.add_term(coeff, cr, ann)
+                        sq_op.add_term(-coeff, ann, cr)
+                        q_op = sq_op.jw_transform(self._qubit_excitations)
+                        U, p = trotterize(
+                            q_op, factor=-tamp, trotter_number=self._trotter_number
+                        )
+                        if p != 1.0 + 0.0j:
+                            raise ValueError(
+                                "Encountered phase change, phase not equal to (1.0 + 0.0i)"
+                            )
+                        Umu.add(U)
+                else:
+                    # The minus sign is dictated by the recursive algorithm used to compute the analytic gradient
+                    # (see original ADAPT-VQE paper)
+                    Umu, pmu = trotterize(
+                        Kmu_prev, factor=-tamp, trotter_number=self._trotter_number
                     )
+
+                    if pmu != 1.0 + 0.0j:
+                        raise ValueError(
+                            "Encountered phase change, phase not equal to (1.0 + 0.0i)"
+                        )
 
             qc_sig.apply_circuit(Umu)
             qc_psi.apply_circuit(Umu)

--- a/tests/test_feb_qeb_circuits.py
+++ b/tests/test_feb_qeb_circuits.py
@@ -8,6 +8,7 @@ class TestEfficientCircuits:
         "method, options",
         [
             (UCCNVQE, {"pool_type": "SD"}),
+            (UCCNVQE, {"pool_type": "sa_SD"}),
             (ADAPTVQE, {"pool_type": "SD", "avqe_thresh": 1.0e-3}),
             (UCCNPQE, {"pool_type": "SD"}),
             (SPQE, {"spqe_thresh": 0.01}),


### PR DESCRIPTION
## Description

### Background
For any second-quantized operator pool, the QForte workflow before this PR was as follows:

![CodeCogsEqn](https://github.com/evangelistalab/qforte/assets/21369033/9bf2c0de-ca74-472c-aa34-5d4d389967c9)

In converting the second-quantized operator pool to a qubit operator, there are two possible options regarding the ordering of the Pauli strings:

1. **Option 1: `"unique_lex"`**
    - **Process**: After all Pauli strings are generated, they are ordered lexicographically. Subsequently, the Trotterization step takes place.
    - **Issue**: Pauli strings stemming from different fermionic anti-Hermitian operators do not necessarily commute, which may result in the breaking of particle number and Sz symmetry.

2. **Option 2 (Default): `"commuting_grp_lex"`**
    - **Process**: Pauli strings originating from a given Pauli string are ordered lexicographically, but no global ordering is imposed.
    - **Advantage**: Since Pauli strings coming from a given Pauli operator commute among themselves, the symmetries of the second-quantized operators are respected.
    - **Exception**: When the `sa_SD` pool is employed, the elements of the second-quantized operator pool are, in general, linear combinations of spin-orbital fermionic anti-Hermitian operators. Reordering these Pauli strings may potentially introduce particle number and Sz symmetry breaking.

### Changes in This PR
To prevent symmetry breaking, the workflow has been modified as follows:

![CodeCogsEqn2](https://github.com/evangelistalab/qforte/assets/21369033/4977f09d-d62c-40ef-bd3d-5c341b976b24)

- **Exact Trotterization**: In the last step, Trotterization is exact since Pauli strings originating from a given fermionic anti-Hermitian operator commute among themselves.
- **Decoupling Trotterization**: By decoupling the Trotterization of the UCC unitary from the Trotterization of the qubit operators, this PR enables the use of FEB/QEB circuits for the `sa_SD` operator pool.

Similar modifications might be beneficial for methods based on Hamiltonian simulation, but this is outside the scope of this PR.

### Testing
- **Updates**: The FEB/QEB test has been updated to include the `sa_SD` pool.
- **Results**: All tests successfully passed.

## User Notes
- [x] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [x] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x] Ready to go!
