### PR TITLE
Separate `refprep` and `Uprep`

### DIFF
--- a/src/qforte/abc/algorithm.py
+++ b/src/qforte/abc/algorithm.py
@@ -82,13 +82,15 @@ class Algorithm(ABC):
                     )
                 self._ref = reference
 
-            self._Uprep = build_Uprep(self._ref, state_prep_type)
+            self._refprep = build_refprep(self._ref)
+            self._Uprep = qf.Circuit(self._refprep)
 
         elif self._state_prep_type == "unitary_circ":
             if not isinstance(reference, qf.Circuit):
                 raise ValueError("unitary_circ reference must be a Circuit.")
 
             self._ref = system.hf_reference
+            self._refprep = build_refprep(self._ref)
             self._Uprep = reference
 
         else:

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -100,7 +100,7 @@ class UCC(Trotterizable):
                 self._orb_e.append(ei)
 
     def get_res_over_mpdenom(self, residuals):
-        """This function returns a vector given by the residuals dividied by the
+        """This function returns a vector given by the residuals divided by the
         respective Moller Plesset denominators.
 
         Parameters
@@ -117,7 +117,7 @@ class UCC(Trotterizable):
             sq_op = self._pool_obj[m][1]
 
             temp_idx = sq_op.terms()[0][2][-1]
-            if temp_idx < int(sum(self._ref) / 2):  # if temp_idx is an occupied idx
+            if self._ref[temp_idx]:  # if temp_idx is an occupied idx
                 sq_creators = sq_op.terms()[0][1]
                 sq_annihilators = sq_op.terms()[0][2]
             else:

--- a/src/qforte/abc/ansatz.py
+++ b/src/qforte/abc/ansatz.py
@@ -8,7 +8,7 @@ the ansatz circut and potential supporting utility functions.
 
 import qforte as qf
 
-from qforte.utils.state_prep import build_Uprep
+from qforte.utils.state_prep import build_refprep
 from qforte.utils.trotterization import trotterize
 from qforte.utils.compact_excitation_circuits import compact_excitation_circuit
 from qforte.abc.mixin import Trotterizable
@@ -82,12 +82,12 @@ class UCC(Trotterizable):
             print("\nBuilding single-particle energies:")
             print("---------------------------------------", flush=True)
             qc = qf.Computer(self._nqb)
-            qc.apply_circuit(build_Uprep(self._ref, "occupation_list"))
+            qc.apply_circuit(self._refprep)
             E0 = qc.direct_op_exp_val(self._qb_ham)
 
             for i in range(self._nqb):
                 qc = qf.Computer(self._nqb)
-                qc.apply_circuit(build_Uprep(self._ref, "occupation_list"))
+                qc.apply_circuit(self._refprep)
                 qc.apply_gate(qf.gate("X", i, i))
                 Ei = qc.direct_op_exp_val(self._qb_ham)
 

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -96,7 +96,7 @@ class QITE(Trotterizable, Algorithm):
         solve the corresponding generailzed eigenvalue problem.
 
     _Ekb : list of float
-        The list of after each additional time step.
+        The list of energies after each additional time step.
 
     _expansion_type: {'complete_qubit', 'cqoy', 'SD', 'GSD', 'SDT', SDTQ', 'SDTQP', 'SDTQPH'}
         The family of operators that each evolution operator :math:`\hat{A}` will be built of.

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -379,7 +379,6 @@ class ADAPTVQE(UCCVQE):
 
         curr_norm = 0.0
         lgrst_grad = 0.0
-        Uvqc = self.build_Uvqc()
 
         if self._verbose:
             print(

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -403,7 +403,7 @@ class SPQE(UCCPQE):
                 # sq_op is 1.0(a^ b^ i j) - 1.0(j^ i^ b a)
 
                 qc_temp = qforte.Computer(self._nqb)
-                qc_temp.apply_circuit(self._Uprep)
+                qc_temp.apply_circuit(self._refprep)
                 qc_temp.apply_operator(sq_op.jw_transform(self._qubit_excitations))
                 sign_adjust = qc_temp.get_coeff_vec()[self._pool_idx_to_coeff_idx[m]]
 

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -243,7 +243,7 @@ class UCCNPQE(UCCPQE):
             I = excited_det.index()
 
             qc_temp = qforte.Computer(self._nqb)
-            qc_temp.apply_circuit(self._Uprep)
+            qc_temp.apply_circuit(self._refprep)
             qc_temp.apply_operator(sq_op.jw_transform(self._qubit_excitations))
             phase_factor = qc_temp.get_coeff_vec()[I]
 

--- a/src/qforte/utils/moment_energy_corrections.py
+++ b/src/qforte/utils/moment_energy_corrections.py
@@ -7,7 +7,7 @@ for traditional coupled-cluster approaches can be found in:
     DOI: 10.1063/1.481769
     DOI: 10.1063/1.2137318
 The use of such moment corrections in the UCC case is experimental
-and a publication will appear in the future.
+and preliminary data is published in 10.1021/acs.jpca.3c02781
 """
 
 import qforte as qf
@@ -92,7 +92,7 @@ def construct_moment_space(self):
     for i in self._mmcc_pool.terms():
         sq_op = i[1]
         qc = qf.Computer(self._nqb)
-        qc.apply_circuit(self._Uprep)
+        qc.apply_circuit(self._refprep)
         # This could be replaced by set_bit?
         qc.apply_operator(sq_op.jw_transform(self._qubit_excitations))
         self._epstein_nesbet.append(qc.direct_op_exp_val(self._qb_ham))

--- a/src/qforte/utils/state_prep.py
+++ b/src/qforte/utils/state_prep.py
@@ -4,8 +4,8 @@ import numpy as np
 
 def build_refprep(ref):
     refprep = qforte.Circuit()
-    for j in range(len(ref)):
-        if ref[j] == 1:
+    for j, occupied in enumerate(ref):
+        if occupied:
             refprep.add(qforte.gate("X", j, j))
 
     return refprep

--- a/src/qforte/utils/state_prep.py
+++ b/src/qforte/utils/state_prep.py
@@ -2,16 +2,13 @@ import qforte
 import numpy as np
 
 
-def build_Uprep(ref, state_prep_type):
-    Uprep = qforte.Circuit()
-    if state_prep_type == "occupation_list":
-        for j in range(len(ref)):
-            if ref[j] == 1:
-                Uprep.add(qforte.gate("X", j, j))
-    else:
-        raise ValueError("Only 'occupation_list' supported as state preparation type")
+def build_refprep(ref):
+    refprep = qforte.Circuit()
+    for j in range(len(ref)):
+        if ref[j] == 1:
+            refprep.add(qforte.gate("X", j, j))
 
-    return Uprep
+    return refprep
 
 
 def ref_string(ref, nqb):


### PR DESCRIPTION
## Description
Several PQE-like functions need to know how to prepare the reference determinant and assume it can be done by applying `self._Uprep`. This can break down if a user supplied an initial `Uprep` circuit, so this task is now delegated to `refprep`.

## User Notes
- [x] Fixed bugs that could occur if a user supplied an initial circuit for a PQE computation or a calculation with moment corrections

## Checklist
- [x] Ready to go!
