### PR TITLE
Fixed warnings in tests

### DIFF
--- a/src/qforte/abc/qsdabc.py
+++ b/src/qforte/abc/qsdabc.py
@@ -14,32 +14,32 @@ import numpy as np
 class QSD(Algorithm):
     """The abstract base class inherited by any algorithm that seeks to find
     eigenstates of the Hamiltonian in a (generally) non-orthogonal basis of
-    many-body states :math:`\{ | \Psi_n \\rangle \}`. The basis is generated
+    many-body states :math:`\\{ | \\Psi_n \\rangle \\}`. The basis is generated
     by a corresponding family of unitary operators
 
     .. math::
-        | \Psi_n \\rangle = \hat{U}_n | \Phi_0 \\rangle
+        | \\Psi_n \\rangle = \\hat{U}_n | \\Phi_0 \\rangle
 
-    where :math:`| \Phi \\rangle` is (usually) an unentangled reference
+    where :math:`| \\Phi \\rangle` is (usually) an unentangled reference
     such as the Hartree-Fock state.
 
     Quantum subspace diagonalization methods work by constructing an effective
-    Hamiltonian :math:`\mathbf{H}` with matrix elements given by
+    Hamiltonian :math:`\\mathbf{H}` with matrix elements given by
 
     .. math::
-        H_{mn} = \\langle \Psi_m | \hat{H} | \Psi_n \\rangle,
+        H_{mn} = \\langle \\Psi_m | \\hat{H} | \\Psi_n \\rangle,
 
-    and overlap matrix :math:`\mathbf{S}` with elemets given by
+    and overlap matrix :math:`\\mathbf{S}` with elemets given by
 
     .. math::
-        S_{mn} = \\langle \Psi_m | \Psi_n \\rangle,
+        S_{mn} = \\langle \\Psi_m | \\Psi_n \\rangle,
 
     both of which can be measured on a quantum device.
 
     These two matrices then comprise a generalized eigenvalue probelm
 
     .. math::
-        \mathbf{H}\mathbf{c} = E \mathbf{S} \mathbf{c},
+        \\mathbf{H}\\mathbf{c} = E \\mathbf{S} \\mathbf{c},
 
     where E is an approximation to an eigenvalue of the Hamiltonian.
 
@@ -75,8 +75,8 @@ class QSD(Algorithm):
 
     @abstractmethod
     def build_qk_mats(self):
-        """Constructs the effective Hamiltonian (:math:`\mathbf{H}`) and overlap
-        (:math:`\mathbf{S}`) matricies in an efficient maner.
+        """Constructs the effective Hamiltonian (:math:`\\mathbf{H}`) and overlap
+        (:math:`\\mathbf{S}`) matricies in an efficient maner.
 
         """
         pass

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -101,8 +101,9 @@ class UCCPQE(UCC, PQE):
     def get_sum_residual_square(self, tamps):
         # This function is passed to scipy minimize for residual minimization
         residual_vector = self.get_residual_vector(tamps)
-        sum_residual_vector_square = np.sum(np.square(residual_vector))
-        return sum_residual_vector_square
+        sum_residual_vector_square = np.sum(np.square(np.abs(residual_vector)))
+        assert sum_residual_vector_square.imag < 1.0e-14
+        return np.real(sum_residual_vector_square)
 
     def solve(self):
         if self._optimizer.lower() == "jacobi":

--- a/src/qforte/abc/uccpqeabc.py
+++ b/src/qforte/abc/uccpqeabc.py
@@ -23,15 +23,15 @@ class UCCPQE(UCC, PQE):
     eigenstates by minimization of the residual condition
 
     .. math::
-        r_\mu = \langle \Phi_\mu | \hat{U}^\dagger(\mathbf{t}) \hat{H} \hat{U}(\mathbf{t}) | \Phi_0 \\rangle \\rightarrow 0
+        r_\\mu = \\langle \\Phi_\\mu | \\hat{U}^\\dagger(\\mathbf{t}) \\hat{H} \\hat{U}(\\mathbf{t}) | \\Phi_0 \\rangle \\rightarrow 0
 
     using a disentagled UCC type ansatz
 
     .. math::
-        \hat{U}(\mathbf{t}) = \prod_\mu e^{t_\mu (\hat{\\tau}_\mu - \hat{\\tau}_\mu^\dagger)},
+        \\hat{U}(\\mathbf{t}) = \\prod_\\mu e^{t_\\mu (\\hat{\\tau}_\\mu - \\hat{\\tau}_\\mu^\\dagger)},
 
-    were :math:`\hat{\\tau}_\mu` is a Fermionic excitation operator and
-    :math:`t_\mu` is a cluster amplitude.
+    were :math:`\\hat{\\tau}_\\mu` is a Fermionic excitation operator and
+    :math:`t_\\mu` is a cluster amplitude.
 
     Attributes
     ----------

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -24,15 +24,15 @@ class UCCVQE(UCC, VQE):
     eigenstates by variational minimization of the Energy
 
     .. math::
-        E(\mathbf{t}) = \langle \Phi_0 | \hat{U}^\dagger(\mathbf{\mathbf{t}}) \hat{H} \hat{U}(\mathbf{\mathbf{t}}) | \Phi_0 \\rangle
+        E(\\mathbf{t}) = \\langle \\Phi_0 | \\hat{U}^\\dagger(\\mathbf{\\mathbf{t}}) \\hat{H} \\hat{U}(\\mathbf{\\mathbf{t}}) | \\Phi_0 \\rangle
 
     using a disentagled UCC type ansatz
 
     .. math::
-        \hat{U}(\mathbf{t}) = \prod_\mu e^{t_\mu (\hat{\\tau}_\mu - \hat{\\tau}_\mu^\dagger)},
+        \\hat{U}(\\mathbf{t}) = \\prod_\\mu e^{t_\\mu (\\hat{\\tau}_\\mu - \\hat{\\tau}_\\mu^\\dagger)},
 
-    were :math:`\hat{\\tau}_\mu` is a Fermionic excitation operator and
-    :math:`t_\mu` is a cluster amplitude.
+    were :math:`\\hat{\\tau}_\\mu` is a Fermionic excitation operator and
+    :math:`t_\\mu` is a cluster amplitude.
 
     Attributes
     ----------

--- a/src/qforte/ite/qite.py
+++ b/src/qforte/ite/qite.py
@@ -27,45 +27,45 @@ class QITE(Trotterizable, Algorithm):
     the focus of the origional algorithm (see DOI 10.1038/s41567-019-0704-4).
 
     In QITE one attepmts to approximate the action of the imaginary time evolution
-    operator on a state :math:`| \Phi \\rangle` with a parameterized unitary
+    operator on a state :math:`| \\Phi \\rangle` with a parameterized unitary
     operation:
 
     .. math::
-        c(\\Delta \\beta)^{-1/2} e^{-\\Delta \\beta \hat{H}} | \Phi \\rangle \\approx e^{-i \\Delta \\beta \hat{A}(\\vec{\\theta})} | \Phi \\rangle,
+        c(\\Delta \\beta)^{-1/2} e^{-\\Delta \\beta \\hat{H}} | \\Phi \\rangle \\approx e^{-i \\Delta \\beta \\hat{A}(\\vec{\\theta})} | \\Phi \\rangle,
 
     where :math:`\\Delta \\beta` is a small time step and
     :math:`c(\\Delta \\beta)^{-1/2}` is a normalization coefficient approximated
-    by :math:`1-2\\Delta \\beta \\langle \Phi | \hat{H} | \Phi \\rangle`.
+    by :math:`1-2\\Delta \\beta \\langle \\Phi | \\hat{H} | \\Phi \\rangle`.
 
-    The parameterized anti-hermetian operator :math:`\hat{A}(\\vec{\\theta})`
-    is given by the linear combination of :math:`N_\mu` operators
+    The parameterized anti-hermetian operator :math:`\\hat{A}(\\vec{\\theta})`
+    is given by the linear combination of :math:`N_\\mu` operators
 
     .. math::
-        \hat{A}(\\vec{\\theta}) = \sum_\mu^{N_\mu} \\theta_\mu \hat{P}_\mu,
+        \\hat{A}(\\vec{\\theta}) = \\sum_\\mu^{N_\\mu} \\theta_\\mu \\hat{P}_\\mu,
 
-    where :math:`\hat{P}_\mu` is a product of Pauli operators. In practice the
+    where :math:`\\hat{P}_\\mu` is a product of Pauli operators. In practice the
     operators that enter in to the sum are a subset of an operator pool specified
     by the user.
 
-    To determine the parameters :math:`\\theta_\mu` one seeks to satisfy the
+    To determine the parameters :math:`\\theta_\\mu` one seeks to satisfy the
     condition:
 
     .. math::
-        c(\\beta)^{-1/2} \\langle \Phi |  \sum_{\mu} \\theta_\mu \hat{P}_\mu^\dagger \hat{H} | \Phi \\rangle
-        \\approx -i  \\langle \Phi | \sum_{\mu} \\theta_\mu \\theta_\\nu \hat{P}_\mu^\dagger  \hat{P}_\\nu | \Phi \\rangle
+        c(\\beta)^{-1/2} \\langle \\Phi |  \\sum_{\\mu} \\theta_\\mu \\hat{P}_\\mu^\\dagger \\hat{H} | \\Phi \\rangle
+        \\approx -i  \\langle \\Phi | \\sum_{\\mu} \\theta_\\mu \\theta_\\nu \\hat{P}_\\mu^\\dagger  \\hat{P}_\\nu | \\Phi \\rangle
 
     which corresponding to solving the linear systems
 
     .. math::
-        \mathbf{S} \\vec{\\theta} = \\vec{b}
+        \\mathbf{S} \\vec{\\theta} = \\vec{b}
 
     where the elements
 
     .. math::
-        S_{\mu \\nu} = \\langle \Phi | \hat{P}_\mu^\dagger \hat{P}_\\nu | \Phi \\rangle,
+        S_{\\mu \\nu} = \\langle \\Phi | \\hat{P}_\\mu^\\dagger \\hat{P}_\\nu | \\Phi \\rangle,
 
     .. math::
-        b_\mu = \\frac{-i}{\sqrt{c(\Delta \\beta)}} \\langle \Phi | \hat{P}_\mu^\dagger \hat{H} | \Phi \\rangle
+        b_\\mu = \\frac{-i}{\\sqrt{c(\\Delta \\beta)}} \\langle \\Phi | \\hat{P}_\\mu^\\dagger \\hat{H} | \\Phi \\rangle
 
     can be measured on a quantum device.
 
@@ -76,14 +76,14 @@ class QITE(Trotterizable, Algorithm):
     ----------
 
     _b_thresh : float
-        The minimum threshold absolute vale for the elements of :math:`b_\mu` to be included
-        in the solving of the linear system. Operators :math:`\hat{P}_\mu`
-        corresponding to elements of :math:`|b_\mu|` < _b_thresh will not enter
-        into the operator :math:`\hat{A}`.
+        The minimum threshold absolute vale for the elements of :math:`b_\\mu` to be included
+        in the solving of the linear system. Operators :math:`\\hat{P}_\\mu`
+        corresponding to elements of :math:`|b_\\mu|` < _b_thresh will not enter
+        into the operator :math:`\\hat{A}`.
 
     _x_thresh : float
-        Operators :math:`\hat{P}_\mu` corresponding to elements of :math:`|\\theta_\mu|`
-        < _b_thresh will not enter into the operator :math:`\hat{A}`.
+        Operators :math:`\\hat{P}_\\mu` corresponding to elements of :math:`|\\theta_\\mu|`
+        < _b_thresh will not enter into the operator :math:`\\hat{A}`.
 
     _beta : float
         The target total evolution time.
@@ -99,7 +99,7 @@ class QITE(Trotterizable, Algorithm):
         The list of after each additional time step.
 
     _expansion_type: {'complete_qubit', 'cqoy', 'SD', 'GSD', 'SDT', SDTQ', 'SDTQP', 'SDTQPH'}
-        The family of operators that each evolution operator :math:`\hat{A}` will be built of.
+        The family of operators that each evolution operator :math:`\\hat{A}` will be built of.
 
     _lanczos_gap : int
         The number of time steps between generation of Lanczos basis vectors.

--- a/src/qforte/qkd/mrsqk.py
+++ b/src/qforte/qkd/mrsqk.py
@@ -31,27 +31,27 @@ from scipy.linalg import eig
 class MRSQK(Trotterizable, QSD):
     """A quantum subspace diagonalization algorithm that generates the many-body
     basis from :math:`s` real time evolutions of :math:`d` differnt orthogonal
-    reference states :math:`| \Phi_I \\rangle`:
+    reference states :math:`| \\Phi_I \\rangle`:
 
     .. math::
-        | \Psi_n^I \\rangle = e^{-i n \Delta t \hat{H}} | \Phi_I \\rangle
+        | \\Psi_n^I \\rangle = e^{-i n \\Delta t \\hat{H}} | \\Phi_I \\rangle
 
     In practice Trotterization is used to approximate the time evolution operator.
 
     The reference states are determined using an initial single-reference QK
-    calculation with its own specified values for the time step :math:`\Delta t_0`
+    calculation with its own specified values for the time step :math:`\\Delta t_0`
     and number of SRQK time evolutions :math:`s_0`. One can then determine from
     the target SRQK eigenvector :math:`\\vec{C}` an estimate of the most important
     determinats via the importance value
 
     .. math::
-        P_I = \sum_n^{s_0 + 1} | \\langle \Phi_I | \Psi_n \\rangle |^2 |C_n|^2.
+        P_I = \\sum_n^{s_0 + 1} | \\langle \\Phi_I | \\Psi_n \\rangle |^2 |C_n|^2.
 
-    The quantity :math:`| \\langle \Phi_I | \Psi_n \\rangle |^2` can be
+    The quantity :math:`| \\langle \\Phi_I | \\Psi_n \\rangle |^2` can be
     approximated by measuring each of time evolved states in the computational
     basis (if the Jordan Wigner transform was used).
 
-    Onece a set of important determinants :math:`\{ \Phi_I \}` is determined it
+    Onece a set of important determinants :math:`\\{ \\Phi_I \\}` is determined it
     is (optionally) augmented to additionally include spin any complements and
     the Hamiltonain is diagonalized in space of the new spin-complement list.
     The final reference states (if _use_spin_adapted_refs==True) are then given
@@ -62,7 +62,7 @@ class MRSQK(Trotterizable, QSD):
     ----------
 
     _d : int
-        The number of reference states :math:`\Phi_I` to use.
+        The number of reference states :math:`\\Phi_I` to use.
 
     _diagonalize_each_step : bool
         For diagnostic purposes, should the eigenvalue of the target root of the
@@ -108,7 +108,7 @@ class MRSQK(Trotterizable, QSD):
     Prelimenary SRQK Reference Specific Keywords
 
     _dt_o : float
-        The time step :math:`\Delta t` to use for SRQK.
+        The time step :math:`\\Delta t` to use for SRQK.
 
     _s_o : int
         The :math:`s` value for SRQK.

--- a/src/qforte/qkd/nt_srqk.py
+++ b/src/qforte/qkd/nt_srqk.py
@@ -23,7 +23,7 @@ class NTSRQK(QSD):
     basis from different durations of non-Trotterized real time evolution:
 
     .. math::
-        | \Psi_n \\rangle = e^{-i n \Delta t \hat{H}} | \Phi_0 \\rangle
+        | \\Psi_n \\rangle = e^{-i n \\Delta t \\hat{H}} | \\Phi_0 \\rangle
 
     In practice Trotterization is used to approximate the time evolution operator.
 

--- a/src/qforte/qkd/srqk.py
+++ b/src/qforte/qkd/srqk.py
@@ -24,7 +24,7 @@ class SRQK(Trotterizable, QSD):
     basis from different durations of real time evolution:
 
     .. math::
-        | \Psi_n \\rangle = e^{-i n \Delta t \hat{H}} | \Phi_0 \\rangle
+        | \\Psi_n \\rangle = e^{-i n \\Delta t \\hat{H}} | \\Phi_0 \\rangle
 
     In practice Trotterization is used to approximate the time evolution operator.
 

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -31,15 +31,15 @@ class ADAPTVQE(UCCVQE):
     In ADAPT-VQE, the unitary ansatz at macro-iteration :math:`k` is defined as
 
     .. math::
-        \hat{U}_\mathrm{ADAPT}^{(k)}(\mathbf{t}) = \prod_\\nu^{k} e^{ t_\\nu^{(k)} \hat{\kappa}_\\nu^{(k)} },
+        \\hat{U}_\\mathrm{ADAPT}^{(k)}(\\mathbf{t}) = \\prod_\\nu^{k} e^{ t_\\nu^{(k)} \\hat{\\kappa}_\\nu^{(k)} },
 
     where the index :math:`\\nu` is likewise a index corresponding to unique operators
-    :math:`\hat{\kappa}_\\nu` in a pool of operators.
+    :math:`\\hat{\\kappa}_\\nu` in a pool of operators.
     Note that the parameters :math:`t_\\nu^{(k)}` are re-optimized at each macro-iteration.
     New operators are determined from the pool by computing the energy gradient
 
     .. math::
-        g_\\nu = \\langle \Psi_\mathrm{VQE} | [ \hat{H}, \hat{\kappa}_\\nu ] | \Psi_\mathrm{VQE} \\rangle,
+        g_\\nu = \\langle \\Psi_\\mathrm{VQE} | [ \\hat{H}, \\hat{\\kappa}_\\nu ] | \\Psi_\\mathrm{VQE} \\rangle,
 
     with respect to :math:`t_\\nu` of each operator in the pool and selecting
     the operator with the largest gradient magnitude to place at the end of

--- a/src/qforte/ucc/spqe.py
+++ b/src/qforte/ucc/spqe.py
@@ -22,34 +22,34 @@ class SPQE(UCCPQE):
     """This class implements the selected projective quantum eigensolver (SPQE) for
     disentagled UCC like ansatz.
     In SPQE, a batch of imporant particle-hole operators
-    :math:`\{ e^{t_\mu (\hat{\\tau}_\mu - \hat{\\tau}_\mu^\dagger )} \}` are
-    added at each macro-iteration :math:`n` to the SPQE unitary :math:`\hat{U}(\mathbf{t})`,
+    :math:`\\{ e^{t_\\mu (\\hat{\\tau}_\\mu - \\hat{\\tau}_\\mu^\\dagger )} \\}` are
+    added at each macro-iteration :math:`n` to the SPQE unitary :math:`\\hat{U}(\\mathbf{t})`,
     wile all current parameters are optimized using the quasi-Newton PQE update
     with micro-iterations :math:`k`.
 
     In our selection approach we consider a (normalized) quantum state of the form
 
     .. math::
-        | \\tilde{r} \\rangle  = \\tilde{r}_0 | \Phi_0 \\rangle + \sum_\mu \\tilde{r}_\mu  | \Phi_\mu \\rangle
+        | \\tilde{r} \\rangle  = \\tilde{r}_0 | \\Phi_0 \\rangle + \\sum_\\mu \\tilde{r}_\\mu  | \\Phi_\\mu \\rangle
 
-    where the quantities :math:`\\tilde{r}_\mu` are approximately proportional to
-    the residuals :math:`r_\mu`.
+    where the quantities :math:`\\tilde{r}_\\mu` are approximately proportional to
+    the residuals :math:`r_\\mu`.
     The state :math:`| \\tilde{r} \\rangle` can be approximately reproduced via
 
     .. math::
-        | \\tilde{r} \\rangle \\approx \hat{U}^\dagger e^{i \Delta t \hat{H}} \hat{U} | \Phi_0 \\rangle
+        | \\tilde{r} \\rangle \\approx \\hat{U}^\\dagger e^{i \\Delta t \\hat{H}} \\hat{U} | \\Phi_0 \\rangle
 
     .. math::
-        \\approx (1 + i\Delta t \hat{U}^\dagger \hat{H} \hat{U})  | \Phi_0 \\rangle + \mathcal{O}(\Delta t^2).
+        \\approx (1 + i\\Delta t \\hat{U}^\\dagger \\hat{H} \\hat{U})  | \\Phi_0 \\rangle + \\mathcal{O}(\\Delta t^2).
 
     We note that in this implementation we use a Trotter approximation for the time
     evolution unitary.
-    Measuring :math:`\\langle \hat{Z} \\rangle` for each qubit yields a bitstring
+    Measuring :math:`\\langle \\hat{Z} \\rangle` for each qubit yields a bitstring
     that has corresponding determinat and operator
-    :math:`(\hat{\\tau}_\mu - \hat{\\tau}_\mu^\dagger )`
-    with probablility proportional to :math:`|\\tilde{r}_\mu|^2`.
-    The operators corresponding to the largest :math:`|\\tilde{r}_\mu|^2` values
-    are then added to :math:`\hat{U}(\mathbf{t})` at each macro-iteration.
+    :math:`(\\hat{\\tau}_\\mu - \\hat{\\tau}_\\mu^\\dagger )`
+    with probablility proportional to :math:`|\\tilde{r}_\\mu|^2`.
+    The operators corresponding to the largest :math:`|\\tilde{r}_\\mu|^2` values
+    are then added to :math:`\\hat{U}(\\mathbf{t})` at each macro-iteration.
     """
 
     def run(

--- a/src/qforte/ucc/uccnpqe.py
+++ b/src/qforte/ucc/uccnpqe.py
@@ -30,17 +30,17 @@ class UCCNPQE(UCCPQE):
     representing the wave function to be simulated, (2) evaluates the residuals
 
     .. math::
-        r_\mu = \langle \Phi_\mu | \hat{U}^\dagger(\mathbf{t}) \hat{H} \hat{U}(\mathbf{t}) | \Phi_0 \\rangle
+        r_\\mu = \\langle \\Phi_\\mu | \\hat{U}^\\dagger(\\mathbf{t}) \\hat{H} \\hat{U}(\\mathbf{t}) | \\Phi_0 \\rangle
 
     and (3) optimizes the wave fuction via projective solution of
     the UCC Schrodinger Equation via a quazi-Newton update equation.
-    Using this strategy, an amplitude :math:`t_\mu^{(k+1)}` for iteration :math:`k+1`
+    Using this strategy, an amplitude :math:`t_\\mu^{(k+1)}` for iteration :math:`k+1`
     is given by
 
     .. math::
-        t_\mu^{(k+1)} = t_\mu^{(k)} + \\frac{r_\mu^{(k)}}{\Delta_\mu}
+        t_\\mu^{(k+1)} = t_\\mu^{(k)} + \\frac{r_\\mu^{(k)}}{\\Delta_\\mu}
 
-    where :math:`\Delta_\mu` is the standard Moller Plesset denominator.
+    where :math:`\\Delta_\\mu` is the standard Moller Plesset denominator.
 
     Attributes
     ----------

--- a/src/qforte/utils/qubit_tapering.py
+++ b/src/qforte/utils/qubit_tapering.py
@@ -190,14 +190,14 @@ def find_parity_check_matrix_kernel(n_qubits, n_strings, prt_chck_mtrx):
         ### Find a non-zero row
         nonzero_indices = np.argwhere(prt_chck_mtrx_aug[row, idx:])
         if nonzero_indices.shape[0] > 0:
-            column_to_be_CEFed = int(nonzero_indices[0]) + idx
+            column_to_be_CEFed = nonzero_indices[0].item() + idx
             ### The first column that is non-zero in this row is the next column to "CEF" - swap positions accordingly
             prt_chck_mtrx_aug[:, [column_to_be_CEFed, idx]] = prt_chck_mtrx_aug[
                 :, [idx, column_to_be_CEFed]
             ]
             ### Eliminate remaining non-zero row elements in the part of the parity check matrix that is not in CEF
             for i in range(1, nonzero_indices.shape[0]):
-                column_not_in_CEF = int(nonzero_indices[i]) + idx
+                column_not_in_CEF = nonzero_indices[i].item() + idx
                 prt_chck_mtrx_aug[:, column_not_in_CEF] = np.bitwise_xor(
                     prt_chck_mtrx_aug[:, idx], prt_chck_mtrx_aug[:, column_not_in_CEF]
                 )
@@ -377,7 +377,7 @@ def find_maximal_Abelian_subgroup(n_qubits, basis, commute, taper_from_least):
         nonzero_indices = np.argwhere(generators_binary[:, column])
         if nonzero_indices.shape[0] == 1:
             if nonzero_indices[0] not in lst:
-                lst.append(int(nonzero_indices[0]))
+                lst.append(nonzero_indices[0].item())
                 idx += 1
         else:
             for i in range(nonzero_indices.shape[0]):
@@ -455,7 +455,7 @@ def taper_operator(tapered_qubits, sign, operator, unitary):
         # List that will store the coefficients modified according to the sign structure provided by the user
         for pauli in circuit.gates():
             if pauli.target() in tapered_qubits:
-                coeff *= sign[int(np.argwhere(tapered_qubits == pauli.target()))]
+                coeff *= sign[np.argwhere(tapered_qubits == pauli.target()).item()]
             else:
                 # Adjust gate targets to account for tapered qubits
                 idx = np.count_nonzero(pauli.target() > tapered_qubits)


### PR DESCRIPTION
## Description

This PR addresses and fixes the thousands of warnings that were issued when running the QForte tests. The warnings can be grouped into three categories:

1. **Invalid Escape Sequence**:
    - These warnings pertained to LaTeX commands appearing in the docstrings.

2. **Deprecation Warning**:
    - This warning was raised whenever qubit tapering was performed. The cause was the unconventional way of extracting the value from a `np.argwhere` result.

3. **Complex Warning**:
    - This warning occurred whenever PQE with residual minimization was employed. This was caused by the sum of residuals squared being of type complex.

---

### Changes

- **Docstrings**: Fixed invalid escape sequences in LaTeX commands by adding the necessary escape characters.
- **Qubit Tapering**: Resolved deprecation warnings by using `.item()` to extract values from `np.argwhere`.
- **PQE Residual Minimization**: Ensured the sum of residuals squared is converted to a real number to eliminate complex warnings.

---

All tests successfully pass and no warnings are issued!

## User Notes
- [ ] Features added
- [ ] Changes to compilation (if any)

## Checklist
- [ ] Added/updated tests of new features
- [ ] Removed comments in input files
- [ ] Documented source code
- [ ] Checked for redundant headers/imports
- [ ] Checked for consistency in the formatting of the output file
- [x] Ready to go!
