### PR TITLE
Remove printing that's specific to gradient-based VQE

### DIFF
--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -313,9 +313,11 @@ class UCCVQE(UCC, VQE):
 
         if self._k_counter == 1:
             header = "\n    k iteration         Energy               dE"
-            if self._use_analytic_grad: header += "           Ngvec ev      Ngm ev*         ||g||"
+            if self._use_analytic_grad:
+                header += "           Ngvec ev      Ngm ev*         ||g||"
             header += "\n------------------------------------------------------"
-            if self._use_analytic_grad: header += "--------------------------------------------"
+            if self._use_analytic_grad:
+                header += "--------------------------------------------"
             print(header)
             if self._print_summary_file:
                 header.replace("\n ", "\n#  ").replace("\n-", "\n#--")
@@ -325,7 +327,8 @@ class UCCVQE(UCC, VQE):
         # else:
         dE = self._curr_energy - self._prev_energy
         update = f"     {self._k_counter:7}        {self._curr_energy:+12.10f}      {dE:+12.10f}"
-        if self._use_analytic_grad: update += f"      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._curr_grad_norm:+12.10f}"
+        if self._use_analytic_grad:
+            update += f"      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._curr_grad_norm:+12.10f}"
         print(update)
 
         if self._print_summary_file:

--- a/src/qforte/abc/uccvqeabc.py
+++ b/src/qforte/abc/uccvqeabc.py
@@ -312,34 +312,26 @@ class UCCVQE(UCC, VQE):
         self._k_counter += 1
 
         if self._k_counter == 1:
-            print(
-                "\n    k iteration         Energy               dE           Ngvec ev      Ngm ev*         ||g||"
-            )
-            print(
-                "--------------------------------------------------------------------------------------------------"
-            )
+            header = "\n    k iteration         Energy               dE"
+            if self._use_analytic_grad: header += "           Ngvec ev      Ngm ev*         ||g||"
+            header += "\n------------------------------------------------------"
+            if self._use_analytic_grad: header += "--------------------------------------------"
+            print(header)
             if self._print_summary_file:
-                f = open("summary.dat", "w+", buffering=1)
-                f.write(
-                    "\n#    k iteration         Energy               dE           Ngvec ev      Ngm ev*         ||g||"
-                )
-                f.write(
-                    "\n#--------------------------------------------------------------------------------------------------"
-                )
-                f.close()
+                header.replace("\n ", "\n#  ").replace("\n-", "\n#--")
+                with open("summary.dat", "w+", buffering=1) as f:
+                    f.write(header)
 
         # else:
         dE = self._curr_energy - self._prev_energy
-        print(
-            f"     {self._k_counter:7}        {self._curr_energy:+12.10f}      {dE:+12.10f}      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._curr_grad_norm:+12.10f}"
-        )
+        update = f"     {self._k_counter:7}        {self._curr_energy:+12.10f}      {dE:+12.10f}"
+        if self._use_analytic_grad: update += f"      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._curr_grad_norm:+12.10f}"
+        print(update)
 
         if self._print_summary_file:
-            f = open("summary.dat", "a", buffering=1)
-            f.write(
-                f"\n       {self._k_counter:7}        {self._curr_energy:+12.12f}      {dE:+12.12f}      {self._res_vec_evals:4}        {self._res_m_evals:6}       {self._curr_grad_norm:+12.12f}"
-            )
-            f.close()
+            with open("summary.dat", "a", buffering=1) as f:
+                update = "\n  " + update
+                f.write(header)
 
         self._prev_energy = self._curr_energy
 

--- a/src/qforte/ucc/adaptvqe.py
+++ b/src/qforte/ucc/adaptvqe.py
@@ -96,6 +96,13 @@ class ADAPTVQE(UCCVQE):
         self._opt_maxiter = opt_maxiter
         self._use_analytic_grad = use_analytic_grad
         self._optimizer = optimizer
+        if self._use_analytic_grad and self._optimizer in {
+            "nelder-mead",
+            "powell",
+            "cobyla",
+        }:
+            print(f"{self._optimizer} optimizer doesn't support analytic grads.")
+            self._use_analytic_grad = False
         self._pool_type = pool_type
         self._use_cumulative_thresh = use_cumulative_thresh
         self._add_equiv_ops = add_equiv_ops

--- a/src/qforte/ucc/uccnvqe.py
+++ b/src/qforte/ucc/uccnvqe.py
@@ -54,6 +54,13 @@ class UCCNVQE(UCCVQE):
         self._opt_maxiter = opt_maxiter
         self._use_analytic_grad = use_analytic_grad
         self._optimizer = optimizer
+        if self._use_analytic_grad and self._optimizer in {
+            "nelder-mead",
+            "powell",
+            "cobyla",
+        }:
+            print(f"{self._optimizer} optimizer doesn't support analytic grads.")
+            self._use_analytic_grad = False
         self._pool_type = pool_type
         self._noise_factor = noise_factor
 


### PR DESCRIPTION
## Description
Previously, UCCVQE would print out gradient diagnostics even for computations without a gradient. This is silly, so I removed them.

To clean up the printing, I also tried to unify the to-screen printing and to-file printing. For some reason I don't understand, to-file printing had more digits but not more space for them. There were also some inconsistencies with the amount of whitespace between the two versions. In both cases, I changed them to be more like the to-screen version. The initial `#` for to-file printing is retained.

## User Notes
- [x] There have been minor changes to output printing for UCCVQE.

## Checklist
- [x] Ready to go!