### PR TITLE
Fix compile issues

### DIFF
--- a/src/qforte/qubit_basis.h
+++ b/src/qforte/qubit_basis.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <numeric>
 #include <string>
 

--- a/src/qforte/sq_op_pool.h
+++ b/src/qforte/sq_op_pool.h
@@ -1,6 +1,7 @@
 #ifndef _sq_op_pool_h_
 #define _sq_op_pool_h_
 
+#include <cstdint>
 #include <complex>
 #include <string>
 #include <vector>


### PR DESCRIPTION
## Description
Fix compile issues on VT's ARC cluster. Use of type `uint64_t` in the edited files [assumes](https://en.cppreference.com/w/cpp/types/integer) inclusion of `cstdint`.

## Checklist
- [x] Ready to go!
